### PR TITLE
Organize src tree with CMake build and C++17 entry

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100
+Standard: c++17

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.10)
+project(3d_project)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_subdirectory(kernel)
+add_subdirectory(sketch)
+add_subdirectory(model)
+add_subdirectory(assembly)
+add_subdirectory(io)
+add_subdirectory(ui)
+
+add_executable(three_d_app main.cpp)
+target_link_libraries(three_d_app
+    kernel
+    sketch
+    model
+    assembly
+    io
+    ui
+)

--- a/src/assembly/CMakeLists.txt
+++ b/src/assembly/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(assembly assembly.cpp)

--- a/src/assembly/assembly.cpp
+++ b/src/assembly/assembly.cpp
@@ -1,0 +1,3 @@
+namespace assembly {
+void placeholder() {}
+} // namespace assembly

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(io io.cpp)

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -1,0 +1,3 @@
+namespace io {
+void placeholder() {}
+} // namespace io

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(kernel kernel.cpp)

--- a/src/kernel/kernel.cpp
+++ b/src/kernel/kernel.cpp
@@ -1,0 +1,3 @@
+namespace kernel {
+void placeholder() {}
+} // namespace kernel

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "3D project entry point" << std::endl;
+    return 0;
+}

--- a/src/model/CMakeLists.txt
+++ b/src/model/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(model model.cpp)

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -1,0 +1,3 @@
+namespace model {
+void placeholder() {}
+} // namespace model

--- a/src/sketch/CMakeLists.txt
+++ b/src/sketch/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(sketch sketch.cpp)

--- a/src/sketch/sketch.cpp
+++ b/src/sketch/sketch.cpp
@@ -1,0 +1,3 @@
+namespace sketch {
+void placeholder() {}
+} // namespace sketch

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(ui ui.cpp)

--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -1,0 +1,3 @@
+namespace ui {
+void placeholder() {}
+} // namespace ui


### PR DESCRIPTION
## Summary
- Add `src` hierarchy with kernel, sketch, model, assembly, io, and ui modules
- Set up CMake build system and `main.cpp` entry point
- Configure project for C++17 and provide `.clang-format`

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68a9659a4e5c832e9aca5589918cc4ef