### PR TITLE
Add basic assembly framework

### DIFF
--- a/examples/assembly_demo.cpp
+++ b/examples/assembly_demo.cpp
@@ -1,0 +1,28 @@
+#include <iostream>
+#include <memory>
+#include "assembly/Assembly.h"
+#include "assembly/mates/PlaneMate.h"
+#include "assembly/mates/AxisMate.h"
+
+int main() {
+    auto compA = std::make_shared<Component>("A");
+    auto compB = std::make_shared<Component>("B");
+
+    Assembly assembly;
+    assembly.addComponent(compA);
+    assembly.addComponent(compB);
+
+    auto planeMate = std::make_shared<PlaneMate>(compA, compB);
+    auto axisMate = std::make_shared<AxisMate>(compA, compB);
+
+    assembly.addMate(planeMate);
+    assembly.addMate(axisMate);
+
+    std::cout << "Assembly has " << assembly.components().size() << " components and "
+              << assembly.mates().size() << " mates." << std::endl;
+    for (const auto& m : assembly.mates()) {
+        std::cout << " - " << m->type() << std::endl;
+    }
+    return 0;
+}
+

--- a/src/assembly/Assembly.cpp
+++ b/src/assembly/Assembly.cpp
@@ -1,0 +1,18 @@
+#include "Assembly.h"
+
+void Assembly::addComponent(std::shared_ptr<Component> comp) {
+    components_.push_back(std::move(comp));
+}
+
+void Assembly::addMate(std::shared_ptr<Mate> mate) {
+    mates_.push_back(std::move(mate));
+}
+
+const std::vector<std::shared_ptr<Component>>& Assembly::components() const {
+    return components_;
+}
+
+const std::vector<std::shared_ptr<Mate>>& Assembly::mates() const {
+    return mates_;
+}
+

--- a/src/assembly/Assembly.h
+++ b/src/assembly/Assembly.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <vector>
+#include <memory>
+#include "Component.h"
+#include "Mate.h"
+
+class Assembly {
+public:
+    void addComponent(std::shared_ptr<Component> comp);
+    void addMate(std::shared_ptr<Mate> mate);
+    const std::vector<std::shared_ptr<Component>>& components() const;
+    const std::vector<std::shared_ptr<Mate>>& mates() const;
+private:
+    std::vector<std::shared_ptr<Component>> components_;
+    std::vector<std::shared_ptr<Mate>> mates_;
+};
+

--- a/src/assembly/Component.cpp
+++ b/src/assembly/Component.cpp
@@ -1,0 +1,8 @@
+#include "Component.h"
+
+Component::Component(std::string name) : name_(std::move(name)) {}
+
+const std::string& Component::name() const {
+    return name_;
+}
+

--- a/src/assembly/Component.h
+++ b/src/assembly/Component.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <string>
+
+class Component {
+public:
+    explicit Component(std::string name);
+    const std::string& name() const;
+private:
+    std::string name_;
+};
+

--- a/src/assembly/Mate.cpp
+++ b/src/assembly/Mate.cpp
@@ -1,0 +1,8 @@
+#include "Mate.h"
+
+Mate::Mate(std::shared_ptr<Component> a, std::shared_ptr<Component> b)
+    : a_(std::move(a)), b_(std::move(b)) {}
+
+std::shared_ptr<Component> Mate::first() const { return a_; }
+std::shared_ptr<Component> Mate::second() const { return b_; }
+

--- a/src/assembly/Mate.h
+++ b/src/assembly/Mate.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <memory>
+#include "Component.h"
+
+class Mate {
+public:
+    Mate(std::shared_ptr<Component> a, std::shared_ptr<Component> b);
+    virtual ~Mate() = default;
+    std::shared_ptr<Component> first() const;
+    std::shared_ptr<Component> second() const;
+    virtual const char* type() const = 0;
+protected:
+    std::shared_ptr<Component> a_;
+    std::shared_ptr<Component> b_;
+};
+

--- a/src/assembly/mates/AxisMate.h
+++ b/src/assembly/mates/AxisMate.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "../Mate.h"
+
+class AxisMate : public Mate {
+public:
+    using Mate::Mate;
+    const char* type() const override { return "AxisMate"; }
+};
+

--- a/src/assembly/mates/PlaneMate.h
+++ b/src/assembly/mates/PlaneMate.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "../Mate.h"
+
+class PlaneMate : public Mate {
+public:
+    using Mate::Mate;
+    const char* type() const override { return "PlaneMate"; }
+};
+


### PR DESCRIPTION
## Summary
- implement basic `Component`, `Mate`, and `Assembly` classes
- add constraint mates `PlaneMate` and `AxisMate`
- provide `assembly_demo.cpp` showing assembly with mates

## Testing
- `g++ -std=c++17 examples/assembly_demo.cpp src/assembly/Assembly.cpp src/assembly/Component.cpp src/assembly/Mate.cpp -I./src -o assembly_demo`
- `./assembly_demo`

------
https://chatgpt.com/codex/tasks/task_e_68a9687f3980832eb3d7484bb73603ea