### PR TITLE
Add mesh IO parsers and internal CAD project format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# 3d_project
+# 3D Project
+
+This repository experiments with simple 3D file parsing and rendering.
+
+## I/O Library
+
+New parsers for common mesh formats live in `src/io/`:
+
+- `obj_parser.c` – loads Wavefront OBJ files.
+- `stl_parser.c` – loads ASCII STL files.
+- `cadproj_io.c` – reads and writes the experimental `.cadproj` format.
+- `step_parser.c` – placeholder for future STEP support via external
+  libraries such as Open Cascade.
+
+The shared `Mesh` data structure is defined in `src/mesh.h`.
+
+See [`docs/cadproj_format.md`](docs/cadproj_format.md) for details on the
+`.cadproj` design.
+

--- a/docs/cadproj_format.md
+++ b/docs/cadproj_format.md
@@ -1,0 +1,29 @@
+# CAD Project File Format (.cadproj)
+
+The `.cadproj` format stores geometry together with placeholders for
+parametric and assembly information. It is a simple text-based format
+intended for experimentation.
+
+## Structure
+
+```
+CADPROJ 1.0
+vertices <count>
+<x> <y> <z>
+...
+faces <count>
+<v1> <v2> <v3>
+...
+# parametric and assembly data would follow
+```
+
+- `CADPROJ 1.0` – file identifier and version.
+- `vertices` section lists all vertex coordinates.
+- `faces` section lists triangular faces referencing vertex indices (1-based).
+- Lines starting with `#` are comments and can include parametric definitions
+  and assembly relationships. Future versions may encode these sections in
+  JSON to interface with external CAD kernels.
+
+This design allows basic geometry exchange today while leaving room for
+parametric features (e.g., sketches, constraints) and assembly hierarchy to be
+added later.

--- a/src/io/cadproj_io.c
+++ b/src/io/cadproj_io.c
@@ -1,0 +1,81 @@
+#include "cadproj_io.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int save_cadproj(const char *filename, const Mesh *mesh) {
+    if (!filename || !mesh) return -1;
+    FILE *file = fopen(filename, "w");
+    if (!file) return -1;
+
+    fprintf(file, "CADPROJ 1.0\n");
+    fprintf(file, "vertices %zu\n", mesh->vertex_count);
+    for (size_t i = 0; i < mesh->vertex_count; ++i) {
+        const Vertex *v = &mesh->vertices[i];
+        fprintf(file, "%f %f %f\n", v->x, v->y, v->z);
+    }
+
+    fprintf(file, "faces %zu\n", mesh->face_count);
+    for (size_t i = 0; i < mesh->face_count; ++i) {
+        const Face *f = &mesh->faces[i];
+        fprintf(file, "%d %d %d\n", f->v1, f->v2, f->v3);
+    }
+
+    fprintf(file, "# parametric and assembly data would follow\n");
+    fclose(file);
+    return 0;
+}
+
+int load_cadproj(const char *filename, Mesh *mesh) {
+    if (!filename || !mesh) return -1;
+    FILE *file = fopen(filename, "r");
+    if (!file) return -1;
+
+    char header[32];
+    if (!fgets(header, sizeof(header), file) || strncmp(header, "CADPROJ", 7) != 0)
+        goto error;
+
+    size_t vcount = 0, fcount = 0, vcap = 0, fcap = 0;
+    mesh->vertices = NULL;
+    mesh->faces = NULL;
+    mesh->vertex_count = 0;
+    mesh->face_count = 0;
+
+    char keyword[32];
+    while (fscanf(file, "%31s", keyword) == 1) {
+        if (strcmp(keyword, "vertices") == 0) {
+            if (fscanf(file, "%zu", &vcount) != 1) goto error;
+            vcap = vcount;
+            mesh->vertices = malloc(vcap * sizeof(Vertex));
+            if (!mesh->vertices) goto error;
+            for (size_t i = 0; i < vcount; ++i) {
+                Vertex *v = &mesh->vertices[i];
+                if (fscanf(file, "%f %f %f", &v->x, &v->y, &v->z) != 3) goto error;
+            }
+            mesh->vertex_count = vcount;
+        } else if (strcmp(keyword, "faces") == 0) {
+            if (fscanf(file, "%zu", &fcount) != 1) goto error;
+            fcap = fcount;
+            mesh->faces = malloc(fcap * sizeof(Face));
+            if (!mesh->faces) goto error;
+            for (size_t i = 0; i < fcount; ++i) {
+                Face *f = &mesh->faces[i];
+                if (fscanf(file, "%d %d %d", &f->v1, &f->v2, &f->v3) != 3) goto error;
+            }
+            mesh->face_count = fcount;
+        } else if (keyword[0] == '#') {
+            fgets(header, sizeof(header), file); // skip comment
+        } else {
+            // Unrecognized section
+            break;
+        }
+    }
+
+    fclose(file);
+    return 0;
+
+error:
+    fclose(file);
+    free_mesh(mesh);
+    return -1;
+}

--- a/src/io/cadproj_io.h
+++ b/src/io/cadproj_io.h
@@ -1,0 +1,11 @@
+#ifndef CADPROJ_IO_H
+#define CADPROJ_IO_H
+
+#include "../mesh.h"
+
+/* Simple internal CAD project format (.cadproj) for storing meshes and
+ * placeholders for parametric and assembly data. */
+int load_cadproj(const char *filename, Mesh *mesh);
+int save_cadproj(const char *filename, const Mesh *mesh);
+
+#endif /* CADPROJ_IO_H */

--- a/src/io/obj_parser.c
+++ b/src/io/obj_parser.c
@@ -1,0 +1,47 @@
+#include "obj_parser.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int parse_obj(const char *filename, Mesh *mesh) {
+    if (!filename || !mesh) return -1;
+    FILE *file = fopen(filename, "r");
+    if (!file) return -1;
+
+    char line[256];
+    size_t vcap = 0, fcap = 0;
+    mesh->vertices = NULL;
+    mesh->faces = NULL;
+    mesh->vertex_count = 0;
+    mesh->face_count = 0;
+
+    while (fgets(line, sizeof(line), file)) {
+        if (line[0] == 'v' && line[1] == ' ') {
+            if (mesh->vertex_count == vcap) {
+                vcap = vcap ? vcap * 2 : 64;
+                mesh->vertices = realloc(mesh->vertices, vcap * sizeof(Vertex));
+                if (!mesh->vertices) goto error;
+            }
+            Vertex *v = &mesh->vertices[mesh->vertex_count++];
+            if (sscanf(line + 2, "%f %f %f", &v->x, &v->y, &v->z) != 3)
+                goto error;
+        } else if (line[0] == 'f' && line[1] == ' ') {
+            if (mesh->face_count == fcap) {
+                fcap = fcap ? fcap * 2 : 64;
+                mesh->faces = realloc(mesh->faces, fcap * sizeof(Face));
+                if (!mesh->faces) goto error;
+            }
+            Face *f = &mesh->faces[mesh->face_count++];
+            if (sscanf(line + 2, "%d %d %d", &f->v1, &f->v2, &f->v3) != 3)
+                goto error;
+        }
+    }
+
+    fclose(file);
+    return 0;
+
+error:
+    fclose(file);
+    free_mesh(mesh);
+    return -1;
+}

--- a/src/io/obj_parser.h
+++ b/src/io/obj_parser.h
@@ -1,0 +1,11 @@
+#ifndef OBJ_PARSER_H
+#define OBJ_PARSER_H
+
+#include "../mesh.h"
+
+/* Parse a Wavefront OBJ file into a Mesh structure.
+ * Returns 0 on success, -1 on failure.
+ */
+int parse_obj(const char *filename, Mesh *mesh);
+
+#endif /* OBJ_PARSER_H */

--- a/src/io/step_parser.c
+++ b/src/io/step_parser.c
@@ -1,0 +1,9 @@
+#include "step_parser.h"
+#include <stdio.h>
+
+int parse_step(const char *filename, Mesh *mesh) {
+    (void)filename;
+    (void)mesh;
+    fprintf(stderr, "STEP parsing not implemented. Future work will integrate Open Cascade.\n");
+    return -1;
+}

--- a/src/io/step_parser.h
+++ b/src/io/step_parser.h
@@ -1,0 +1,10 @@
+#ifndef STEP_PARSER_H
+#define STEP_PARSER_H
+
+#include "../mesh.h"
+
+/* Placeholder for STEP parsing. The implementation is expected to use
+ * an external library such as Open Cascade in the future. */
+int parse_step(const char *filename, Mesh *mesh);
+
+#endif /* STEP_PARSER_H */

--- a/src/io/stl_parser.c
+++ b/src/io/stl_parser.c
@@ -1,0 +1,50 @@
+#include "stl_parser.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int parse_stl(const char *filename, Mesh *mesh) {
+    if (!filename || !mesh) return -1;
+    FILE *file = fopen(filename, "r");
+    if (!file) return -1;
+
+    char line[256];
+    size_t vcap = 0, fcap = 0;
+    mesh->vertices = NULL;
+    mesh->faces = NULL;
+    mesh->vertex_count = 0;
+    mesh->face_count = 0;
+
+    while (fgets(line, sizeof(line), file)) {
+        if (strncmp(line, "vertex", 6) == 0) {
+            if (mesh->vertex_count == vcap) {
+                vcap = vcap ? vcap * 2 : 64;
+                mesh->vertices = realloc(mesh->vertices, vcap * sizeof(Vertex));
+                if (!mesh->vertices) goto error;
+            }
+            Vertex *v = &mesh->vertices[mesh->vertex_count++];
+            if (sscanf(line + 6, "%f %f %f", &v->x, &v->y, &v->z) != 3)
+                goto error;
+        } else if (strncmp(line, "endfacet", 8) == 0) {
+            if (mesh->face_count == fcap) {
+                fcap = fcap ? fcap * 2 : 64;
+                mesh->faces = realloc(mesh->faces, fcap * sizeof(Face));
+                if (!mesh->faces) goto error;
+            }
+            Face *f = &mesh->faces[mesh->face_count++];
+            size_t base = mesh->vertex_count;
+            // Each facet adds 3 vertices sequentially
+            f->v1 = base - 3;
+            f->v2 = base - 2;
+            f->v3 = base - 1;
+        }
+    }
+
+    fclose(file);
+    return 0;
+
+error:
+    fclose(file);
+    free_mesh(mesh);
+    return -1;
+}

--- a/src/io/stl_parser.h
+++ b/src/io/stl_parser.h
@@ -1,0 +1,11 @@
+#ifndef STL_PARSER_H
+#define STL_PARSER_H
+
+#include "../mesh.h"
+
+/* Parse an ASCII STL file into a Mesh structure.
+ * Returns 0 on success, -1 on failure.
+ */
+int parse_stl(const char *filename, Mesh *mesh);
+
+#endif /* STL_PARSER_H */

--- a/src/mesh.c
+++ b/src/mesh.c
@@ -1,0 +1,12 @@
+#include "mesh.h"
+#include <stdlib.h>
+
+void free_mesh(Mesh *mesh) {
+    if (!mesh) return;
+    free(mesh->vertices);
+    free(mesh->faces);
+    mesh->vertices = NULL;
+    mesh->faces = NULL;
+    mesh->vertex_count = 0;
+    mesh->face_count = 0;
+}

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -1,0 +1,24 @@
+#ifndef MESH_H
+#define MESH_H
+
+#include <stddef.h>
+
+/* Basic data structures for 3D meshes used by parsers */
+typedef struct {
+    float x, y, z;
+} Vertex;
+
+typedef struct {
+    int v1, v2, v3;
+} Face;
+
+typedef struct {
+    Vertex *vertices;
+    size_t vertex_count;
+    Face *faces;
+    size_t face_count;
+} Mesh;
+
+void free_mesh(Mesh *mesh);
+
+#endif /* MESH_H */


### PR DESCRIPTION
## Summary
- add OBJ and ASCII STL parsers under src/io
- sketch future STEP support using an external library
- introduce experimental CAD project format (.cadproj) with load/save helpers

## Testing
- `gcc -c src/mesh.c src/io/obj_parser.c src/io/stl_parser.c src/io/step_parser.c src/io/cadproj_io.c`


------
https://chatgpt.com/codex/tasks/task_e_68a96888df24832e9019d2877b107218