### PR TITLE
Refactor mesh builder to index vertices

### DIFF
--- a/src/kernel/mesh_builder.cpp
+++ b/src/kernel/mesh_builder.cpp
@@ -4,9 +4,11 @@ namespace kernel {
 
 Mesh buildMeshFromSketch(const Sketch& sketch) {
     Mesh mesh;
+    // copy vertices into the mesh
+    mesh.vertices = sketch.vertices;
     // For every three vertices in the sketch create one triangular face
-    for (size_t i = 0; i + 2 < sketch.points.size(); i += 3) {
-        Face f{sketch.points[i], sketch.points[i + 1], sketch.points[i + 2]};
+    for (size_t i = 0; i + 2 < sketch.vertices.size(); i += 3) {
+        Face f{i, i + 1, i + 2};
         mesh.faces.push_back(f);
     }
     return mesh;

--- a/src/kernel/mesh_builder.h
+++ b/src/kernel/mesh_builder.h
@@ -1,23 +1,26 @@
 #pragma once
 
+
 #include <vector>
+#include "vector3.h"
 
 namespace kernel {
 
-// Basic sketch representation as a list of vertex coordinates
+// Basic sketch representation as a list of vertices
 struct Sketch {
-    std::vector<double> points; // x,y,z triples stored sequentially
+    std::vector<Vector3> vertices;
 };
 
 // Triangle face referencing three vertex indices
 struct Face {
-    double v1;
-    double v2;
-    double v3;
+    size_t v1;
+    size_t v2;
+    size_t v3;
 };
 
-// Simple mesh container
+// Simple mesh container holding vertices and faces
 struct Mesh {
+    std::vector<Vector3> vertices;
     std::vector<Face> faces;
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,3 +7,8 @@ add_executable(test_step_parser
     ../src/io/step_parser.c
     ../src/mesh.c)
 add_test(NAME test_step_parser COMMAND test_step_parser)
+
+add_executable(test_mesh_builder
+    test_mesh_builder.cpp
+    ../src/kernel/mesh_builder.cpp)
+add_test(NAME test_mesh_builder COMMAND test_mesh_builder)

--- a/tests/test_mesh_builder.cpp
+++ b/tests/test_mesh_builder.cpp
@@ -1,0 +1,23 @@
+#include <cassert>
+#include "../src/kernel/mesh_builder.h"
+
+int main() {
+    kernel::Sketch sketch;
+    sketch.vertices = {
+        Vector3(0,0,0), Vector3(1,0,0), Vector3(0,1,0),
+        Vector3(0,0,1), Vector3(1,1,0), Vector3(1,0,1)
+    };
+
+    kernel::Mesh mesh = kernel::buildMeshFromSketch(sketch);
+
+    assert(mesh.vertices.size() == 6);
+    assert(mesh.faces.size() == 2);
+
+    assert(mesh.faces[0].v1 == 0 && mesh.faces[0].v2 == 1 && mesh.faces[0].v3 == 2);
+    assert(mesh.faces[1].v1 == 3 && mesh.faces[1].v2 == 4 && mesh.faces[1].v3 == 5);
+
+    assert(mesh.vertices[1] == Vector3(1,0,0));
+    assert(mesh.vertices[4] == Vector3(1,1,0));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Refactor kernel::Sketch to store a vector of Vector3 vertices
- Build Mesh objects using vertex indices with corresponding vertex list
- Add unit test covering simple mesh creation from sketches

## Testing
- `cmake --build build --target test_model_io`
- `cmake --build build --target test_step_parser`
- `cmake --build build --target test_mesh_builder`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68a976163348832eb2ddea73194badee