### PR TITLE
Implement robust constraint solver with regression tests

### DIFF
--- a/src/sketch/constraint_manager.cpp
+++ b/src/sketch/constraint_manager.cpp
@@ -1,5 +1,6 @@
 #include "constraint_manager.h"
 #include <cmath>
+#include <algorithm>
 
 void ConstraintManager::addParameter(double* param) {
     params.push_back(param);
@@ -9,31 +10,112 @@ void ConstraintManager::addConstraint(const std::function<double()>& c) {
     constraints.push_back(c);
 }
 
-void ConstraintManager::solve(int iterations, double lr) {
+// --- constraint helpers -------------------------------------------------
+
+void ConstraintManager::addCoincident(Point2D& a, Point2D& b) {
+    addConstraint([&]() { return a.x - b.x; });
+    addConstraint([&]() { return a.y - b.y; });
+}
+
+void ConstraintManager::addPerpendicular(EntityLine& l1, EntityLine& l2) {
+    addConstraint([&]() {
+        double dx1 = l1.p2.x - l1.p1.x;
+        double dy1 = l1.p2.y - l1.p1.y;
+        double dx2 = l2.p2.x - l2.p1.x;
+        double dy2 = l2.p2.y - l2.p1.y;
+        return dx1 * dx2 + dy1 * dy2; // dot product should be zero
+    });
+}
+
+void ConstraintManager::addEqualLength(EntityLine& l1, EntityLine& l2) {
+    addConstraint([&]() {
+        double dx1 = l1.p2.x - l1.p1.x;
+        double dy1 = l1.p2.y - l1.p1.y;
+        double dx2 = l2.p2.x - l2.p1.x;
+        double dy2 = l2.p2.y - l2.p1.y;
+        double len1 = std::sqrt(dx1 * dx1 + dy1 * dy1);
+        double len2 = std::sqrt(dx2 * dx2 + dy2 * dy2);
+        return len1 - len2;
+    });
+}
+
+// --- solver --------------------------------------------------------------
+
+static std::vector<double> solveLinearSystem(std::vector<double> A, std::vector<double> b, int n) {
+    // Simple Gauss-Jordan elimination
+    for (int i = 0; i < n; ++i) {
+        // Pivot
+        int pivot = i;
+        for (int r = i + 1; r < n; ++r) {
+            if (std::fabs(A[r*n + i]) > std::fabs(A[pivot*n + i]))
+                pivot = r;
+        }
+        if (pivot != i) {
+            for (int c = 0; c < n; ++c)
+                std::swap(A[i*n + c], A[pivot*n + c]);
+            std::swap(b[i], b[pivot]);
+        }
+        double diag = A[i*n + i];
+        if (std::fabs(diag) < 1e-12)
+            continue; // singular; skip
+        for (int c = i; c < n; ++c)
+            A[i*n + c] /= diag;
+        b[i] /= diag;
+        for (int r = 0; r < n; ++r) {
+            if (r == i) continue;
+            double factor = A[r*n + i];
+            for (int c = i; c < n; ++c)
+                A[r*n + c] -= factor * A[i*n + c];
+            b[r] -= factor * b[i];
+        }
+    }
+    return b; // contains solution
+}
+
+void ConstraintManager::solve(int iterations, double damping) {
     const double eps = 1e-6;
+    const int n = static_cast<int>(params.size());
+    const int m = static_cast<int>(constraints.size());
     for (int it = 0; it < iterations; ++it) {
-        // Compute gradients
-        std::vector<double> grads(params.size(), 0.0);
-        for (size_t i = 0; i < params.size(); ++i) {
-            double orig = *params[i];
-            *params[i] = orig + eps;
-            double err1 = 0.0;
-            for (auto &c : constraints) {
-                double v = c();
-                err1 += v * v;
+        // Evaluate constraint residuals
+        std::vector<double> f(m);
+        for (int i = 0; i < m; ++i)
+            f[i] = constraints[i]();
+
+        // Build Jacobian (finite differences)
+        std::vector<double> J(m * n, 0.0);
+        for (int j = 0; j < n; ++j) {
+            double orig = *params[j];
+            *params[j] = orig + eps;
+            for (int i = 0; i < m; ++i) {
+                double fp = constraints[i]();
+                J[i*n + j] = (fp - f[i]) / eps;
             }
-            *params[i] = orig - eps;
-            double err2 = 0.0;
-            for (auto &c : constraints) {
-                double v = c();
-                err2 += v * v;
+            *params[j] = orig; // reset
+        }
+
+        // Form normal equations J^T J * dx = -J^T f
+        std::vector<double> A(n*n, 0.0);
+        std::vector<double> b(n, 0.0);
+        for (int i = 0; i < m; ++i) {
+            for (int j = 0; j < n; ++j) {
+                double Jij = J[i*n + j];
+                b[j] += -Jij * f[i];
+                for (int k = 0; k < n; ++k)
+                    A[j*n + k] += Jij * J[i*n + k];
             }
-            grads[i] = (err1 - err2) / (2 * eps);
-            *params[i] = orig; // reset
         }
-        // Apply gradient step
-        for (size_t i = 0; i < params.size(); ++i) {
-            *params[i] -= lr * grads[i];
+        for (int j = 0; j < n; ++j)
+            A[j*n + j] += damping;
+
+        std::vector<double> dx = solveLinearSystem(A, b, n);
+
+        double maxStep = 0.0;
+        for (int j = 0; j < n; ++j) {
+            *params[j] += dx[j];
+            maxStep = std::max(maxStep, std::fabs(dx[j]));
         }
+        if (maxStep < 1e-8)
+            break; // converged
     }
 }

--- a/src/sketch/constraint_manager.h
+++ b/src/sketch/constraint_manager.h
@@ -1,12 +1,21 @@
 #pragma once
 #include <vector>
 #include <functional>
+#include "entity_line.h"
 
 class ConstraintManager {
 public:
     void addParameter(double* param);
     void addConstraint(const std::function<double()>& c);
-    void solve(int iterations = 100, double lr = 0.1);
+
+    // Convenience helpers for common sketch constraints
+    void addCoincident(Point2D& a, Point2D& b);
+    void addPerpendicular(EntityLine& l1, EntityLine& l2);
+    void addEqualLength(EntityLine& l1, EntityLine& l2);
+
+    // Solve the nonlinear least squares system using a simple
+    // Levenberg–Marquardt style Gauss–Newton iteration.
+    void solve(int iterations = 20, double damping = 1e-3);
 private:
     std::vector<double*> params;
     std::vector<std::function<double()>> constraints;

--- a/src/sketch/sketch.h
+++ b/src/sketch/sketch.h
@@ -10,6 +10,9 @@ public:
     EntityLine& addLine(Point2D a, Point2D b);
     EntityCircle& addCircle(Point2D c, double r);
     void addConstraint(const std::function<double()>& c);
+    void addCoincident(Point2D& a, Point2D& b) { cm.addCoincident(a,b); }
+    void addPerpendicular(EntityLine& l1, EntityLine& l2) { cm.addPerpendicular(l1,l2); }
+    void addEqualLength(EntityLine& l1, EntityLine& l2) { cm.addEqualLength(l1,l2); }
     void solve();
     const std::vector<EntityLine>& getLines() const { return lines; }
     const std::vector<EntityCircle>& getCircles() const { return circles; }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_CXX_STANDARD 17)
+
 add_executable(test_model_io test_model_io.c)
 target_compile_definitions(test_model_io PRIVATE UNIT_TEST)
 add_test(NAME test_model_io COMMAND test_model_io)
@@ -12,3 +14,11 @@ add_executable(test_mesh_builder
     test_mesh_builder.cpp
     ../src/kernel/mesh_builder.cpp)
 add_test(NAME test_mesh_builder COMMAND test_mesh_builder)
+
+add_executable(test_constraints
+    test_constraints.cpp
+    ../src/sketch/sketch.cpp
+    ../src/sketch/constraint_manager.cpp
+    ../src/sketch/entity_line.cpp
+    ../src/sketch/entity_circle.cpp)
+add_test(NAME test_constraints COMMAND test_constraints)

--- a/tests/test_constraints.cpp
+++ b/tests/test_constraints.cpp
@@ -1,0 +1,74 @@
+#include <cassert>
+#include <cmath>
+#include "../src/sketch/sketch.h"
+
+int main() {
+    // Coincident constraint test
+    {
+        Sketch s;
+        auto &l1 = s.addLine({0,0},{1,0});
+        auto &l2 = s.addLine({0,1},{1,1});
+        // fix l1 endpoints
+        s.addConstraint([&]{ return l1.p1.x - 0.0; });
+        s.addConstraint([&]{ return l1.p1.y - 0.0; });
+        s.addConstraint([&]{ return l1.p2.x - 1.0; });
+        s.addConstraint([&]{ return l1.p2.y - 0.0; });
+        // fix l2 second endpoint
+        s.addConstraint([&]{ return l2.p2.x - 1.0; });
+        s.addConstraint([&]{ return l2.p2.y - 1.0; });
+        s.addCoincident(l1.p2, l2.p1);
+        s.solve();
+        assert(std::fabs(l1.p2.x - l2.p1.x) < 1e-3);
+        assert(std::fabs(l1.p2.y - l2.p1.y) < 1e-3);
+    }
+
+    // Perpendicular + equal length test
+    {
+        Sketch s;
+        auto &l1 = s.addLine({0,0},{1,0});
+        auto &l2 = s.addLine({0,0},{1,1});
+        // fix l1
+        s.addConstraint([&]{ return l1.p1.x - 0.0; });
+        s.addConstraint([&]{ return l1.p1.y - 0.0; });
+        s.addConstraint([&]{ return l1.p2.x - 1.0; });
+        s.addConstraint([&]{ return l1.p2.y - 0.0; });
+        // fix l2 start point
+        s.addConstraint([&]{ return l2.p1.x - 0.0; });
+        s.addConstraint([&]{ return l2.p1.y - 0.0; });
+        s.addPerpendicular(l1, l2);
+        s.addEqualLength(l1, l2);
+        s.solve();
+        double dx1 = l1.p2.x - l1.p1.x;
+        double dy1 = l1.p2.y - l1.p1.y;
+        double dx2 = l2.p2.x - l2.p1.x;
+        double dy2 = l2.p2.y - l2.p1.y;
+        double dot = dx1*dx2 + dy1*dy2;
+        double len1 = std::sqrt(dx1*dx1 + dy1*dy1);
+        double len2 = std::sqrt(dx2*dx2 + dy2*dy2);
+        assert(std::fabs(dot) < 1e-3);
+        assert(std::fabs(len1 - len2) < 1e-3);
+    }
+
+    // Equal length standalone
+    {
+        Sketch s;
+        auto &l1 = s.addLine({0,0},{2,0});
+        auto &l2 = s.addLine({0,0},{0,1});
+        // fix l1
+        s.addConstraint([&]{ return l1.p1.x - 0.0; });
+        s.addConstraint([&]{ return l1.p1.y - 0.0; });
+        s.addConstraint([&]{ return l1.p2.x - 2.0; });
+        s.addConstraint([&]{ return l1.p2.y - 0.0; });
+        // fix l2 start point
+        s.addConstraint([&]{ return l2.p1.x - 0.0; });
+        s.addConstraint([&]{ return l2.p1.y - 0.0; });
+        s.addEqualLength(l1, l2);
+        s.solve();
+        double dx2 = l2.p2.x - l2.p1.x;
+        double dy2 = l2.p2.y - l2.p1.y;
+        double len2 = std::sqrt(dx2*dx2 + dy2*dy2);
+        assert(std::fabs(len2 - 2.0) < 1e-3);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Replace gradient descent in `ConstraintManager` with a simple Levenberg–Marquardt style Gauss–Newton solver
- Add built-in helpers for coincident, perpendicular and equal-length constraints
- Cover common constraint scenarios with regression tests

## Testing
- `cd build && make test_constraints test_mesh_builder test_model_io test_step_parser`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68a976c56a24832ea7d66ff41af09775