### PR TITLE
Add mesh-based extrusion and revolve features

### DIFF
--- a/src/model/feature.cpp
+++ b/src/model/feature.cpp
@@ -1,22 +1,93 @@
 #include "feature.h"
-#include <iostream>
+#include "../kernel/mesh.h"
+#include <cmath>
+
+using kernel::MeshCpp;
 
 namespace model {
 
-ExtrudeFeature::ExtrudeFeature(const std::vector<double>& sketch, double distance)
+ExtrudeFeature::ExtrudeFeature(const std::vector<Vector3>& sketch, double distance)
     : m_sketch(sketch), m_distance(distance) {}
 
-void ExtrudeFeature::generate() {
-    // Placeholder implementation that would create a B-Rep from the sketch
-    std::cout << "Generating extruded feature of distance " << m_distance << std::endl;
+void ExtrudeFeature::setDistance(double d) {
+    m_distance = d;
+    notifyChanged();
 }
 
-RevolveFeature::RevolveFeature(const std::vector<double>& sketch, double angle)
+Mesh ExtrudeFeature::generate() const {
+    MeshCpp mesh;
+    size_t n = m_sketch.size();
+    if (n < 3) {
+        return kernel::to_c_mesh(mesh);
+    }
+    // bottom vertices
+    for (const auto &p : m_sketch) {
+        mesh.vertices.emplace_back(p.x, p.y, p.z);
+    }
+    // top vertices
+    for (const auto &p : m_sketch) {
+        mesh.vertices.emplace_back(p.x, p.y, p.z + m_distance);
+    }
+    // bottom and top faces (fan)
+    for (size_t i = 1; i + 1 < n; ++i) {
+        mesh.faces.push_back(Face{0, static_cast<int>(i + 1), static_cast<int>(i)});
+        mesh.faces.push_back(Face{static_cast<int>(n), static_cast<int>(n + i), static_cast<int>(n + i + 1)});
+    }
+    // side faces
+    for (size_t i = 0; i < n; ++i) {
+        size_t next = (i + 1) % n;
+        int b1 = static_cast<int>(i);
+        int b2 = static_cast<int>(next);
+        int t1 = static_cast<int>(i + n);
+        int t2 = static_cast<int>(next + n);
+        mesh.faces.push_back(Face{b1, b2, t1});
+        mesh.faces.push_back(Face{b2, t2, t1});
+    }
+    return kernel::to_c_mesh(mesh);
+}
+
+RevolveFeature::RevolveFeature(const std::vector<Vector3>& sketch, double angle)
     : m_sketch(sketch), m_angle(angle) {}
 
-void RevolveFeature::generate() {
-    // Placeholder implementation that would create a revolved B-Rep from the sketch
-    std::cout << "Generating revolved feature of angle " << m_angle << std::endl;
+void RevolveFeature::setAngle(double a) {
+    m_angle = a;
+    notifyChanged();
+}
+
+Mesh RevolveFeature::generate() const {
+    MeshCpp mesh;
+    size_t n = m_sketch.size();
+    if (n < 2) {
+        return kernel::to_c_mesh(mesh);
+    }
+    bool closed = std::abs(m_angle - 360.0) < 1e-6;
+    int segments = closed ? 16 : std::max(3, static_cast<int>(std::ceil(m_angle / 15.0)));
+    double angle_rad = m_angle * M_PI / 180.0;
+    double step = closed ? 2 * M_PI / segments : angle_rad / segments;
+    int ring_count = closed ? segments : segments + 1;
+    for (int s = 0; s < ring_count; ++s) {
+        double theta = step * s;
+        double ct = std::cos(theta);
+        double st = std::sin(theta);
+        for (const auto &p : m_sketch) {
+            double x = p.x * ct - p.y * st;
+            double y = p.x * st + p.y * ct;
+            mesh.vertices.emplace_back(x, y, p.z);
+        }
+    }
+    for (int s = 0; s < segments; ++s) {
+        int ring0 = s * n;
+        int ring1 = closed ? ((s + 1) % segments) * n : (s + 1) * n;
+        for (size_t i = 0; i + 1 < n; ++i) {
+            int v00 = ring0 + i;
+            int v01 = ring0 + i + 1;
+            int v10 = ring1 + i;
+            int v11 = ring1 + i + 1;
+            mesh.faces.push_back(Face{v00, v01, v10});
+            mesh.faces.push_back(Face{v01, v11, v10});
+        }
+    }
+    return kernel::to_c_mesh(mesh);
 }
 
 } // namespace model

--- a/src/model/feature.h
+++ b/src/model/feature.h
@@ -1,32 +1,46 @@
 #pragma once
 #include <vector>
+#include <functional>
+#include "../kernel/mesh.h"
+#include "../kernel/vector3.h"
 
 namespace model {
 
+// Base class for modeling features which can notify when parameters change
 class Feature {
 public:
     virtual ~Feature() = default;
     // Generate the underlying geometry for the feature
-    virtual void generate() = 0;
+    virtual Mesh generate() const = 0;
+
+    void setOnChanged(std::function<void()> cb) { onChanged_ = std::move(cb); }
+
+protected:
+    void notifyChanged() { if (onChanged_) onChanged_(); }
+
+private:
+    std::function<void()> onChanged_;
 };
 
 // Simple extrude feature using a sketch profile and distance
 class ExtrudeFeature : public Feature {
 public:
-    ExtrudeFeature(const std::vector<double>& sketch, double distance);
-    void generate() override;
+    ExtrudeFeature(const std::vector<Vector3>& sketch, double distance);
+    Mesh generate() const override;
+    void setDistance(double d);
 private:
-    std::vector<double> m_sketch;
+    std::vector<Vector3> m_sketch;
     double m_distance;
 };
 
 // Revolve feature using a sketch profile and angle in degrees
 class RevolveFeature : public Feature {
 public:
-    RevolveFeature(const std::vector<double>& sketch, double angle);
-    void generate() override;
+    RevolveFeature(const std::vector<Vector3>& sketch, double angle);
+    Mesh generate() const override;
+    void setAngle(double a);
 private:
-    std::vector<double> m_sketch;
+    std::vector<Vector3> m_sketch;
     double m_angle;
 };
 

--- a/src/model/history_tree.cpp
+++ b/src/model/history_tree.cpp
@@ -1,115 +1,37 @@
-#include <vector>
-#include <memory>
-#include <string>
-#include <functional>
+#include "history_tree.h"
+#include "../kernel/boolean.h"
+#include "../kernel/mesh.h"
 
-// Simple representation of geometry for demonstration purposes.
-struct Geometry {
-    std::vector<std::string> operations; // sequence of operations applied
-};
+namespace model {
 
-// Base class for all modeling features.
-class Feature {
-public:
-    virtual ~Feature() = default;
+HistoryTree::~HistoryTree() {
+    free_mesh(&geometry_);
+}
 
-    // Evaluate this feature and append to geometry.
-    virtual void evaluate(Geometry &geom) = 0;
+void HistoryTree::addFeature(const std::shared_ptr<Feature>& feature) {
+    feature->setOnChanged([this]() { evaluate(); });
+    features_.push_back(feature);
+    evaluate();
+}
 
-    // Called by HistoryTree to register callback when parameters change.
-    void setOnChanged(std::function<void()> cb) { onChanged_ = std::move(cb); }
-
-protected:
-    // Utility to notify tree when parameters were modified.
-    void notifyChanged() {
-        if (onChanged_) onChanged_();
-    }
-
-private:
-    std::function<void()> onChanged_;
-};
-
-// Feature that extrudes a profile with adjustable height.
-class ExtrudeFeature : public Feature {
-public:
-    explicit ExtrudeFeature(double h) : height_(h) {}
-
-    void setHeight(double h) {
-        height_ = h;
-        notifyChanged();
-    }
-
-    double height() const { return height_; }
-
-    void evaluate(Geometry &geom) override {
-        geom.operations.push_back("Extrude:" + std::to_string(height_));
-    }
-
-private:
-    double height_;
-};
-
-// Feature that fillets an edge with adjustable radius.
-class FilletFeature : public Feature {
-public:
-    explicit FilletFeature(double r) : radius_(r) {}
-
-    void setRadius(double r) {
-        radius_ = r;
-        notifyChanged();
-    }
-
-    double radius() const { return radius_; }
-
-    void evaluate(Geometry &geom) override {
-        geom.operations.push_back("Fillet:" + std::to_string(radius_));
-    }
-
-private:
-    double radius_;
-};
-
-// History tree that maintains an ordered sequence of features.
-class HistoryTree {
-public:
-    // Add a new feature to the tree and evaluate.
-    void addFeature(const std::shared_ptr<Feature> &feature) {
-        feature->setOnChanged([this]() { evaluate(); });
-        features_.push_back(feature);
-        evaluate();
-    }
-
-    // Re-evaluate all features to update the geometry.
-    void evaluate() {
-        geometry_.operations.clear();
-        for (const auto &f : features_) {
-            f->evaluate(geometry_);
+void HistoryTree::evaluate() {
+    Mesh result{};
+    bool first = true;
+    for (const auto &f : features_) {
+        Mesh geom = f->generate();
+        if (first) {
+            result = geom;
+            first = false;
+        } else {
+            Mesh combined = boolean_union(result, geom);
+            free_mesh(&result);
+            free_mesh(&geom);
+            result = combined;
         }
     }
-
-    const Geometry &geometry() const { return geometry_; }
-
-private:
-    std::vector<std::shared_ptr<Feature>> features_;
-    Geometry geometry_;
-};
-
-// Example usage (for compilation check only).
-#ifdef HISTORY_TREE_EXAMPLE
-#include <iostream>
-int main() {
-    HistoryTree tree;
-    auto extrude = std::make_shared<ExtrudeFeature>(5.0);
-    tree.addFeature(extrude);
-    auto fillet = std::make_shared<FilletFeature>(1.0);
-    tree.addFeature(fillet);
-
-    // Modify parameter; tree re-evaluates automatically.
-    extrude->setHeight(10.0);
-
-    for (const auto &op : tree.geometry().operations) {
-        std::cout << op << std::endl;
-    }
-    return 0;
+    free_mesh(&geometry_);
+    geometry_ = result;
 }
-#endif
+
+} // namespace model
+

--- a/src/model/history_tree.h
+++ b/src/model/history_tree.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <vector>
+#include <memory>
+#include "feature.h"
+#include "../kernel/mesh.h"
+
+namespace model {
+
+class HistoryTree {
+public:
+    HistoryTree() = default;
+    ~HistoryTree();
+
+    void addFeature(const std::shared_ptr<Feature>& feature);
+    void evaluate();
+    const Mesh& geometry() const { return geometry_; }
+
+private:
+    std::vector<std::shared_ptr<Feature>> features_;
+    Mesh geometry_{};
+};
+
+} // namespace model
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,3 +23,11 @@ add_executable(test_constraints
     ../src/sketch/entity_line.cpp
     ../src/sketch/entity_circle.cpp)
 add_test(NAME test_constraints COMMAND test_constraints)
+
+add_executable(test_features
+    test_features.cpp
+    ../src/model/feature.cpp
+    ../src/model/history_tree.cpp
+    ../src/kernel/mesh.c
+    ../src/kernel/boolean.cpp)
+add_test(NAME test_features COMMAND test_features)

--- a/tests/test_features.cpp
+++ b/tests/test_features.cpp
@@ -1,0 +1,53 @@
+#include <cassert>
+#include <cmath>
+#include <memory>
+#include "../src/model/feature.h"
+#include "../src/model/history_tree.h"
+
+static double computeVolume(const Mesh &mesh) {
+    double vol = 0.0;
+    for (size_t i = 0; i < mesh.face_count; ++i) {
+        const Face &f = mesh.faces[i];
+        const Vertex &a = mesh.vertices[f.v1];
+        const Vertex &b = mesh.vertices[f.v2];
+        const Vertex &c = mesh.vertices[f.v3];
+        double v = a.x*(b.y*c.z - b.z*c.y) - a.y*(b.x*c.z - b.z*c.x) + a.z*(b.x*c.y - b.y*c.x);
+        vol += v;
+    }
+    return std::fabs(vol) / 6.0;
+}
+
+int main() {
+    using ::Vector3;
+    using model::ExtrudeFeature;
+    using model::RevolveFeature;
+    using model::HistoryTree;
+
+    // Test extrude feature
+    std::vector<Vector3> square = { {0,0,0}, {1,0,0}, {1,1,0}, {0,1,0} };
+    auto extrude = std::make_shared<ExtrudeFeature>(square, 1.0);
+    HistoryTree tree1;
+    tree1.addFeature(extrude);
+    const Mesh &m1 = tree1.geometry();
+    assert(m1.face_count == 12);
+    double vol1 = computeVolume(m1);
+    assert(std::fabs(vol1 - 1.0) < 1e-6);
+    extrude->setDistance(2.0);
+    const Mesh &m2 = tree1.geometry();
+    double vol2 = computeVolume(m2);
+    assert(std::fabs(vol2 - 2.0) < 1e-6);
+
+    // Test revolve feature
+    std::vector<Vector3> profile = { {0,0,0}, {1,0,0}, {1,0,1}, {0,0,1} };
+    auto revolve = std::make_shared<RevolveFeature>(profile, 360.0);
+    HistoryTree tree2;
+    tree2.addFeature(revolve);
+    const Mesh &mr = tree2.geometry();
+    double volr = computeVolume(mr);
+    assert(std::fabs(volr - M_PI) < 0.1);
+    revolve->setAngle(180.0);
+    double volr2 = computeVolume(tree2.geometry());
+    assert(std::fabs(volr2 - (M_PI/2)) < 0.1);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Implement mesh-generating ExtrudeFeature and RevolveFeature
- Introduce HistoryTree that rebuilds geometry when parameters change
- Add unit tests confirming correct volumes and face counts for extrusion and revolve

## Testing
- `cmake --build . --target test_features`
- `cmake --build . --target test_model_io test_step_parser test_mesh_builder test_constraints`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68a97b44f164832e9dcde42e0d91f3a0