### PR TITLE
Add ImGui material editor and demo

### DIFF
--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -5,3 +5,6 @@ add_library(ui
     sketch_view.cpp
     viewport.cpp
 )
+
+add_executable(property_panel_example property_panel_example.cpp)
+target_link_libraries(property_panel_example ui)

--- a/src/ui/property_panel.cpp
+++ b/src/ui/property_panel.cpp
@@ -1,9 +1,17 @@
 #include "property_panel.h"
-#include <iostream>
+#include <imgui.h>
 
-void edit_material(Material& material) {
-    std::cout << "Enter density: ";
-    std::cin >> material.density;
-    std::cout << "Enter color (r g b): ";
-    std::cin >> material.color.r >> material.color.g >> material.color.b;
+bool edit_material(Material& material) {
+    bool changed = false;
+    changed |= ImGui::InputFloat("Density", &material.density);
+
+    float color[3] = {material.color.r, material.color.g, material.color.b};
+    if (ImGui::ColorEdit3("Color", color)) {
+        material.color.r = color[0];
+        material.color.g = color[1];
+        material.color.b = color[2];
+        changed = true;
+    }
+
+    return changed;
 }

--- a/src/ui/property_panel.h
+++ b/src/ui/property_panel.h
@@ -3,6 +3,7 @@
 
 #include "../model/material.h"
 
-void edit_material(Material& material);
+// Returns true if any property was modified.
+bool edit_material(Material& material);
 
 #endif // UI_PROPERTY_PANEL_H

--- a/src/ui/property_panel_example.cpp
+++ b/src/ui/property_panel_example.cpp
@@ -1,0 +1,42 @@
+#include "imgui_layer.h"
+#include "property_panel.h"
+#include "../model/material.h"
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
+#include <imgui.h>
+
+int main() {
+    if (!glfwInit())
+        return -1;
+    GLFWwindow* window = glfwCreateWindow(800, 600, "Material Panel Demo", nullptr, nullptr);
+    if (!window) {
+        glfwTerminate();
+        return -1;
+    }
+    glfwMakeContextCurrent(window);
+    gladLoadGLLoader((GLADloadproc)glfwGetProcAddress);
+    ImGuiLayer::Init(window);
+
+    Material material;
+    while (!glfwWindowShouldClose(window)) {
+        glfwPollEvents();
+
+        ImGuiLayer::Begin();
+        if (ImGui::Begin("Material")) {
+            edit_material(material);
+        }
+        ImGui::End();
+
+        glViewport(0, 0, 800, 600);
+        glClearColor(material.color.r, material.color.g, material.color.b, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        ImGuiLayer::End();
+        glfwSwapBuffers(window);
+    }
+
+    ImGuiLayer::Shutdown();
+    glfwDestroyWindow(window);
+    glfwTerminate();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Replace console-based material editing with ImGui controls
- Expose property panel through new demo app

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: GLFW/glfw3.h not found)*
- `cd build && ctest` *(1 failing: test_constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68a98ce61558832e8d4c13c2e0c28741