### PR TITLE
Expand architecture and user manual

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,9 +1,49 @@
 # Architecture
 
-The project consists of several simple C modules:
+This project is organized into modular libraries that together form a minimal 3D CAD environment. The top-level executable `three_d_app` links all modules:
 
-- `3d_model_io.c` implements basic OBJ file loading and saving.
-- `3d_model_viewer.c` provides a simple OpenGL viewer for OBJ models.
-- `3d_points_and_line.c` demonstrates drawing points, lines, and axes with OpenGL.
+- **kernel** – core math and mesh operations (vector/matrix types, boolean ops, mesh builders, mass properties).
+- **sketch** – 2D sketching system with geometric entities and a constraint solver.
+- **model** – feature-based modeling (extrude, revolve, fillet, chamfer) built on kernel geometry. Includes a history tree and materials.
+- **assembly** – manages components and applies mates between them (AxisMate, PlaneMate) to define relationships.
+- **io** – import/export of native `.cadproj` and common formats such as OBJ, STL and STEP.
+- **ui** – ImGui-based user interface providing viewport rendering and property panels.
 
-Tests focus on the model I/O module. CI builds and executes these tests on each push.
+## Relationships
+
+- `sketch` and `model` rely on the geometric foundations provided by `kernel`.
+- `model` consumes sketches to create features and exposes geometry to `assembly` and `io`.
+- `assembly` organizes multiple models and applies mates using kernel mathematics.
+- `io` serializes models and assemblies to various file formats.
+- `ui` drives user interaction and invokes sketch, model and assembly operations.
+- `three_d_app` ties everything together by linking all modules.
+
+```mermaid
+graph TD
+    subgraph Application
+        A[three_d_app]
+    end
+    K[kernel] --> S[sketch]
+    K --> M[model]
+    K --> Asm[assembly]
+    S --> M
+    M --> Asm
+    M --> IO
+    Asm --> IO
+    A --> UI
+    UI --> S
+    UI --> M
+    UI --> Asm
+```
+
+## Build Instructions
+
+The project uses CMake to generate build files. From the repository root:
+
+```bash
+cmake -S . -B build
+cmake --build build
+ctest --test-dir build
+```
+
+All modules are built as static libraries and linked into the `three_d_app` executable. Tests live under the `tests/` directory and can be executed with `ctest` as shown above.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,16 +1,58 @@
 # User Manual
 
-This project provides simple utilities for loading, saving, and viewing 3D models.
+This project provides a minimal 3D CAD toolchain for experimenting with sketching, parametric features, and simple assemblies.
 
 ## Building
 
-The project uses CMake. To build:
+The project uses CMake. To configure, build, and run tests:
 
 ```bash
 cmake -S . -B build
 cmake --build build
+ctest --test-dir build
 ```
 
 ## Running
 
-The repository contains small demo applications for model I/O, a viewer, and drawing points and lines. After building, run the desired executable from the build directory.
+After building, launch the main application:
+
+```bash
+./build/three_d_app
+```
+
+### Sketcher
+
+- Choose **Sketch Mode** in the UI or run the `sketch_view` demo.
+- Use the line and circle tools to place entities.
+- Apply constraints such as coincident, perpendicular, or equal length.
+- Press **Solve** to run the constraint solver and update geometry.
+
+### Feature Creation
+
+- Use a completed sketch as the profile for features.
+- Create an **Extrude** or **Revolve** feature and adjust its parameters.
+- Modify features using operations like **Fillet** or **Chamfer** to refine edges.
+- The history tree updates when features change.
+
+### Assembly Mates
+
+- Insert models as components into an assembly.
+- Constrain components using mates:
+  - **AxisMate** aligns two component axes.
+  - **PlaneMate** makes planar faces coincident.
+- Solving mates positions components relative to each other.
+
+### User Interface
+
+The UI uses ImGui and provides:
+
+- A **viewport** for 3D navigation.
+- A **property panel** for editing feature and mate parameters.
+- Menu options to switch modes, import/export models, and run the solver.
+
+### Workflow Overview
+
+```mermaid
+graph LR
+    Sketch --> Feature --> Model --> Assembly --> Export
+```


### PR DESCRIPTION
## Summary
- Document all major modules, their relationships, and build instructions with a Mermaid diagram.
- Extend the user manual with sketcher usage, feature creation, assembly mates, and UI details, including a workflow diagram.

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: GLFW/glfw3.h: No such file or directory)*
- `ctest --test-dir build` *(passes)*

------
https://chatgpt.com/codex/tasks/task_e_68a98de3f188832e8a9f2c0bd7fe7cc3