### PR TITLE
Validate STL facet vertex count

### DIFF
--- a/src/io/stl_parser.c
+++ b/src/io/stl_parser.c
@@ -4,12 +4,15 @@
 #include <string.h>
 
 int parse_stl(const char *filename, Mesh *mesh) {
-    if (!filename || !mesh) return -1;
+    if (!filename || !mesh)
+        return -1;
     FILE *file = fopen(filename, "r");
-    if (!file) return -1;
+    if (!file)
+        return -1;
 
     char line[256];
     size_t vcap = 0, fcap = 0;
+    size_t facet_vertex_count = 0;
     mesh->vertices = NULL;
     mesh->faces = NULL;
     mesh->vertex_count = 0;
@@ -19,24 +22,31 @@ int parse_stl(const char *filename, Mesh *mesh) {
         if (strncmp(line, "vertex", 6) == 0) {
             if (mesh->vertex_count == vcap) {
                 vcap = vcap ? vcap * 2 : 64;
-                mesh->vertices = realloc(mesh->vertices, vcap * sizeof(Vertex));
-                if (!mesh->vertices) goto error;
+                Vertex *tmp = realloc(mesh->vertices, vcap * sizeof(Vertex));
+                if (!tmp)
+                    goto error;
+                mesh->vertices = tmp;
             }
             Vertex *v = &mesh->vertices[mesh->vertex_count++];
             if (sscanf(line + 6, "%f %f %f", &v->x, &v->y, &v->z) != 3)
                 goto error;
+            facet_vertex_count++;
         } else if (strncmp(line, "endfacet", 8) == 0) {
+            if (facet_vertex_count != 3)
+                goto error;
             if (mesh->face_count == fcap) {
                 fcap = fcap ? fcap * 2 : 64;
-                mesh->faces = realloc(mesh->faces, fcap * sizeof(Face));
-                if (!mesh->faces) goto error;
+                Face *tmp = realloc(mesh->faces, fcap * sizeof(Face));
+                if (!tmp)
+                    goto error;
+                mesh->faces = tmp;
             }
             Face *f = &mesh->faces[mesh->face_count++];
             size_t base = mesh->vertex_count;
-            // Each facet adds 3 vertices sequentially
             f->v1 = base - 3;
             f->v2 = base - 2;
             f->v3 = base - 1;
+            facet_vertex_count = 0;
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure STL parser safely grows vertex and face arrays using temporary pointers
- track vertices per facet and validate exactly three before constructing faces

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: fatal error: GLFW/glfw3.h: No such file or directory)*
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a9bf1bde80832e97775a0e8a8b79d2