### PR TITLE
Preserve entity addresses in sketch using lists

### DIFF
--- a/src/sketch/sketch.cpp
+++ b/src/sketch/sketch.cpp
@@ -2,17 +2,21 @@
 #include "sketch.h"
 
 EntityLine& Sketch::addLine(Point2D a, Point2D b) {
+    // std::list keeps previously inserted elements at stable addresses, so
+    // parameter pointers stored in the ConstraintManager remain valid.
     lines.emplace_back(a, b);
-    auto params = lines.back().parameters();
+    EntityLine &line = lines.back();
+    auto params = line.parameters();
     for (auto *p : params) cm.addParameter(p);
-    return lines.back();
+    return line;
 }
 
 EntityCircle& Sketch::addCircle(Point2D c, double r) {
     circles.emplace_back(c, r);
-    auto params = circles.back().parameters();
+    EntityCircle &circle = circles.back();
+    auto params = circle.parameters();
     for (auto *p : params) cm.addParameter(p);
-    return circles.back();
+    return circle;
 }
 
 void Sketch::addConstraint(const std::function<double()>& c) {

--- a/src/sketch/sketch.h
+++ b/src/sketch/sketch.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <vector>
+#include <list>
 #include <functional>
 #include "entity_line.h"
 #include "entity_circle.h"
@@ -14,10 +14,13 @@ public:
     void addPerpendicular(EntityLine& l1, EntityLine& l2) { cm.addPerpendicular(l1,l2); }
     void addEqualLength(EntityLine& l1, EntityLine& l2) { cm.addEqualLength(l1,l2); }
     void solve(int iterations = 20);
-    const std::vector<EntityLine>& getLines() const { return lines; }
-    const std::vector<EntityCircle>& getCircles() const { return circles; }
+    const std::list<EntityLine>& getLines() const { return lines; }
+    const std::list<EntityCircle>& getCircles() const { return circles; }
 private:
-    std::vector<EntityLine> lines;
-    std::vector<EntityCircle> circles;
+    // Use std::list to keep entity addresses stable so that parameter
+    // pointers registered with the ConstraintManager remain valid after
+    // inserting new elements.
+    std::list<EntityLine> lines;
+    std::list<EntityCircle> circles;
     ConstraintManager cm;
 };


### PR DESCRIPTION
## Summary
- Store sketch lines and circles in `std::list` to keep entity addresses stable
- Update `Sketch::addLine` and `Sketch::addCircle` to work with the new containers and register parameters safely

## Testing
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68a9c006d420832ea90191cabcaefa86