### PR TITLE
Preserve faces in boolean operations

### DIFF
--- a/src/kernel/boolean.cpp
+++ b/src/kernel/boolean.cpp
@@ -1,11 +1,32 @@
 #include "boolean.h"
 #include <algorithm>
 #include <vector>
+#include <cmath>
 #include "vector3.h"
 
 namespace {
+    constexpr double EPS = 1e-6;
+
+    int find_vertex(const std::vector<Vector3> &verts, const Vector3 &v) {
+        for (size_t i = 0; i < verts.size(); ++i) {
+            const auto &o = verts[i];
+            if (std::fabs(o.x - v.x) < EPS &&
+                std::fabs(o.y - v.y) < EPS &&
+                std::fabs(o.z - v.z) < EPS) {
+                return static_cast<int>(i);
+            }
+        }
+        return -1;
+    }
+
     bool contains(const std::vector<Vector3> &verts, const Vector3 &v) {
-        return std::find(verts.begin(), verts.end(), v) != verts.end();
+        return find_vertex(verts, v) != -1;
+    }
+
+    bool contains(const std::vector<Face> &faces, const Face &f) {
+        return std::find_if(faces.begin(), faces.end(), [&](const Face &o) {
+            return o.v1 == f.v1 && o.v2 == f.v2 && o.v3 == f.v3;
+        }) != faces.end();
     }
 }
 
@@ -14,11 +35,25 @@ Mesh boolean_union(const Mesh &a, const Mesh &b) {
     kernel::MeshCpp bc = kernel::to_cpp_mesh(b);
     kernel::MeshCpp rc;
     rc.vertices = ac.vertices;
-    for (const auto &v : bc.vertices) {
-        if (!contains(rc.vertices, v)) {
-            rc.vertices.push_back(v);
+    rc.faces = ac.faces;
+
+    std::vector<int> index_map(bc.vertices.size());
+    for (size_t i = 0; i < bc.vertices.size(); ++i) {
+        int idx = find_vertex(rc.vertices, bc.vertices[i]);
+        if (idx == -1) {
+            rc.vertices.push_back(bc.vertices[i]);
+            idx = static_cast<int>(rc.vertices.size() - 1);
+        }
+        index_map[i] = idx;
+    }
+
+    for (const auto &f : bc.faces) {
+        Face mapped{index_map[f.v1], index_map[f.v2], index_map[f.v3]};
+        if (!contains(rc.faces, mapped)) {
+            rc.faces.push_back(mapped);
         }
     }
+
     return kernel::to_c_mesh(rc);
 }
 
@@ -26,11 +61,26 @@ Mesh boolean_subtract(const Mesh &a, const Mesh &b) {
     kernel::MeshCpp ac = kernel::to_cpp_mesh(a);
     kernel::MeshCpp bc = kernel::to_cpp_mesh(b);
     kernel::MeshCpp rc;
-    for (const auto &v : ac.vertices) {
-        if (!contains(bc.vertices, v)) {
-            rc.vertices.push_back(v);
+    std::vector<int> index_map(ac.vertices.size(), -1);
+    for (size_t i = 0; i < ac.vertices.size(); ++i) {
+        if (!contains(bc.vertices, ac.vertices[i])) {
+            index_map[i] = static_cast<int>(rc.vertices.size());
+            rc.vertices.push_back(ac.vertices[i]);
         }
     }
+
+    for (const auto &f : ac.faces) {
+        int v1 = index_map[f.v1];
+        int v2 = index_map[f.v2];
+        int v3 = index_map[f.v3];
+        if (v1 != -1 && v2 != -1 && v3 != -1) {
+            Face mapped{v1, v2, v3};
+            if (!contains(rc.faces, mapped)) {
+                rc.faces.push_back(mapped);
+            }
+        }
+    }
+
     return kernel::to_c_mesh(rc);
 }
 
@@ -38,12 +88,39 @@ Mesh boolean_intersect(const Mesh &a, const Mesh &b) {
     kernel::MeshCpp ac = kernel::to_cpp_mesh(a);
     kernel::MeshCpp bc = kernel::to_cpp_mesh(b);
     kernel::MeshCpp rc;
-    for (const auto &v : ac.vertices) {
-        if (contains(bc.vertices, v)) {
-            if (!contains(rc.vertices, v)) {
-                rc.vertices.push_back(v);
+    std::vector<int> index_map_ac(ac.vertices.size(), -1);
+    for (size_t i = 0; i < ac.vertices.size(); ++i) {
+        if (contains(bc.vertices, ac.vertices[i])) {
+            int idx = find_vertex(rc.vertices, ac.vertices[i]);
+            if (idx == -1) {
+                rc.vertices.push_back(ac.vertices[i]);
+                idx = static_cast<int>(rc.vertices.size() - 1);
+            }
+            index_map_ac[i] = idx;
+        }
+    }
+
+    for (const auto &f : ac.faces) {
+        int a1 = index_map_ac[f.v1];
+        int a2 = index_map_ac[f.v2];
+        int a3 = index_map_ac[f.v3];
+        if (a1 == -1 || a2 == -1 || a3 == -1) {
+            continue;
+        }
+        int b1 = find_vertex(bc.vertices, ac.vertices[f.v1]);
+        int b2 = find_vertex(bc.vertices, ac.vertices[f.v2]);
+        int b3 = find_vertex(bc.vertices, ac.vertices[f.v3]);
+        if (b1 == -1 || b2 == -1 || b3 == -1) {
+            continue;
+        }
+        Face bf{b1, b2, b3};
+        if (contains(bc.faces, bf)) {
+            Face mapped{a1, a2, a3};
+            if (!contains(rc.faces, mapped)) {
+                rc.faces.push_back(mapped);
             }
         }
     }
+
     return kernel::to_c_mesh(rc);
 }

--- a/tests/kernel/test_kernel.cpp
+++ b/tests/kernel/test_kernel.cpp
@@ -20,20 +20,31 @@ int main() {
 
     // Boolean tests
     kernel::MeshCpp a_cpp;
-    a_cpp.vertices = {Vector3(0,0,0), Vector3(1,0,0)};
+    a_cpp.vertices = {Vector3(0,0,0), Vector3(1,0,0), Vector3(0,1,0)};
+    a_cpp.faces = { {0,1,2} };
     kernel::MeshCpp b_cpp;
-    b_cpp.vertices = {Vector3(1,0,0), Vector3(2,0,0)};
+    b_cpp.vertices = {Vector3(1,0,0), Vector3(0,1,0), Vector3(0,0,1)};
+    b_cpp.faces = { {0,1,2} };
     Mesh a = kernel::to_c_mesh(a_cpp);
     Mesh b = kernel::to_c_mesh(b_cpp);
 
     Mesh u = boolean_union(a,b);
-    assert(u.vertex_count == 3);
+    assert(u.vertex_count == 4);
+    assert(u.face_count == 2);
+    bool has012 = false, has123 = false;
+    for (size_t fi = 0; fi < u.face_count; ++fi) {
+        const Face &f = u.faces[fi];
+        if (f.v1 == 0 && f.v2 == 1 && f.v3 == 2) has012 = true;
+        if (f.v1 == 1 && f.v2 == 2 && f.v3 == 3) has123 = true;
+    }
+    assert(has012 && has123);
 
     Mesh s = boolean_subtract(a,b);
-    assert(s.vertex_count == 1 && s.vertices[0].x == 0 && s.vertices[0].y == 0 && s.vertices[0].z == 0);
+    assert(s.vertex_count == 1 && s.face_count == 0 &&
+           s.vertices[0].x == 0 && s.vertices[0].y == 0 && s.vertices[0].z == 0);
 
     Mesh i = boolean_intersect(a,b);
-    assert(i.vertex_count == 1 && i.vertices[0].x == 1 && i.vertices[0].y == 0 && i.vertices[0].z == 0);
+    assert(i.vertex_count == 2 && i.face_count == 0);
 
     free_mesh(&a);
     free_mesh(&b);


### PR DESCRIPTION
## Summary
- Propagate face data through boolean_union, boolean_subtract, and boolean_intersect.
- Use epsilon-based vertex comparisons to avoid floating point equality issues.
- Extend kernel boolean tests to assert face handling.

## Testing
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_68a9c1981928832ebe54cfadb297dfb5