### PR TITLE
Add platform abstraction layer for Win32 and X11

### DIFF
--- a/include/platform.h
+++ b/include/platform.h
@@ -1,0 +1,29 @@
+#ifndef PLATFORM_H
+#define PLATFORM_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Initialize platform specific windowing system. Returns 0 on success. */
+int platform_init(const char *title, int width, int height);
+
+/* Poll for OS events. Returns non-zero when the application should quit. */
+int platform_poll(void);
+
+/* Present a pixel buffer of size width*height to the window. */
+void platform_present(const uint32_t *pixels);
+
+/* Sleep for the specified number of milliseconds. */
+void platform_sleep(int milliseconds);
+
+/* Shutdown the windowing system and release resources. */
+void platform_shutdown(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PLATFORM_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(model)
 add_subdirectory(assembly)
 add_subdirectory(io)
 add_subdirectory(ui)
+add_subdirectory(platform)
 
 add_executable(three_d_app main.cpp)
 target_link_libraries(three_d_app
@@ -13,4 +14,5 @@ target_link_libraries(three_d_app
     assembly
     io
     ui
+    platform
 )

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(platform)
+
+target_include_directories(platform PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+if (WIN32)
+    target_sources(platform PRIVATE win32_platform.c)
+else()
+    find_package(X11 REQUIRED)
+    target_sources(platform PRIVATE x11_platform.c)
+    target_link_libraries(platform PUBLIC X11::X11)
+endif()

--- a/src/platform/win32_platform.c
+++ b/src/platform/win32_platform.c
@@ -1,0 +1,94 @@
+#include "platform.h"
+#ifdef _WIN32
+#include <windows.h>
+#include <stdlib.h>
+#include <string.h>
+
+static HWND hwnd;
+static HDC hdc;
+static void *backbuffer;
+static BITMAPINFO bmi;
+static int buffer_width;
+static int buffer_height;
+static int running = 1;
+
+static LRESULT CALLBACK wnd_proc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    if (msg == WM_CLOSE || msg == WM_DESTROY) {
+        running = 0;
+        PostQuitMessage(0);
+        return 0;
+    }
+    return DefWindowProc(hWnd, msg, wParam, lParam);
+}
+
+int platform_init(const char *title, int width, int height) {
+    buffer_width = width;
+    buffer_height = height;
+    WNDCLASS wc = {0};
+    wc.lpfnWndProc = wnd_proc;
+    wc.hInstance = GetModuleHandle(NULL);
+    wc.lpszClassName = "three_d_app_class";
+    if (!RegisterClass(&wc))
+        return -1;
+
+    hwnd = CreateWindowEx(0, wc.lpszClassName, title ? title : "app",
+                          WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+                          CW_USEDEFAULT, CW_USEDEFAULT, width, height,
+                          NULL, NULL, wc.hInstance, NULL);
+    if (!hwnd)
+        return -1;
+
+    hdc = GetDC(hwnd);
+
+    ZeroMemory(&bmi, sizeof(bmi));
+    bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biWidth = width;
+    bmi.bmiHeader.biHeight = -height; /* top-down */
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 32;
+    bmi.bmiHeader.biCompression = BI_RGB;
+
+    backbuffer = malloc(width * height * 4);
+    return backbuffer ? 0 : -1;
+}
+
+int platform_poll(void) {
+    MSG msg;
+    while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
+        if (msg.message == WM_QUIT) {
+            running = 0;
+            return 1;
+        }
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+    }
+    return running ? 0 : 1;
+}
+
+void platform_present(const uint32_t *pixels) {
+    if (!backbuffer)
+        return;
+    memcpy(backbuffer, pixels, buffer_width * buffer_height * 4);
+    StretchDIBits(hdc, 0, 0, buffer_width, buffer_height, 0, 0,
+                  buffer_width, buffer_height, backbuffer, &bmi,
+                  DIB_RGB_COLORS, SRCCOPY);
+}
+
+void platform_sleep(int milliseconds) {
+    Sleep(milliseconds);
+}
+
+void platform_shutdown(void) {
+    if (backbuffer) {
+        free(backbuffer);
+        backbuffer = NULL;
+    }
+    if (hwnd && hdc)
+        ReleaseDC(hwnd, hdc);
+    if (hwnd)
+        DestroyWindow(hwnd);
+    hwnd = NULL;
+    hdc = NULL;
+    running = 0;
+}
+#endif /* _WIN32 */

--- a/src/platform/x11_platform.c
+++ b/src/platform/x11_platform.c
@@ -1,0 +1,84 @@
+#include "platform.h"
+#ifndef _WIN32
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static Display *display;
+static Window window;
+static GC gc;
+static XImage *image;
+static Atom wm_delete_window;
+static int buffer_width;
+static int buffer_height;
+
+int platform_init(const char *title, int width, int height) {
+    display = XOpenDisplay(NULL);
+    if (!display)
+        return -1;
+    int screen = DefaultScreen(display);
+    buffer_width = width;
+    buffer_height = height;
+    window = XCreateSimpleWindow(display, RootWindow(display, screen),
+                                 0, 0, width, height, 1,
+                                 BlackPixel(display, screen),
+                                 WhitePixel(display, screen));
+    XStoreName(display, window, title ? title : "app");
+    XSelectInput(display, window, ExposureMask | KeyPressMask | StructureNotifyMask);
+    gc = XCreateGC(display, window, 0, NULL);
+    XMapWindow(display, window);
+    wm_delete_window = XInternAtom(display, "WM_DELETE_WINDOW", False);
+    XSetWMProtocols(display, window, &wm_delete_window, 1);
+
+    char *data = malloc(width * height * 4);
+    if (!data)
+        return -1;
+    image = XCreateImage(display, DefaultVisual(display, screen), 24, ZPixmap, 0,
+                         data, width, height, 32, 0);
+    if (!image)
+        return -1;
+    return 0;
+}
+
+int platform_poll(void) {
+    while (XPending(display)) {
+        XEvent event;
+        XNextEvent(display, &event);
+        if (event.type == ClientMessage && (Atom)event.xclient.data.l[0] == wm_delete_window)
+            return 1;
+        if (event.type == DestroyNotify)
+            return 1;
+    }
+    return 0;
+}
+
+void platform_present(const uint32_t *pixels) {
+    if (!image)
+        return;
+    memcpy(image->data, pixels, buffer_width * buffer_height * 4);
+    XPutImage(display, window, gc, image, 0, 0, 0, 0, buffer_width, buffer_height);
+    XFlush(display);
+}
+
+void platform_sleep(int milliseconds) {
+    usleep((useconds_t)milliseconds * 1000);
+}
+
+void platform_shutdown(void) {
+    if (image) {
+        XDestroyImage(image);
+        image = NULL;
+    }
+    if (gc)
+        XFreeGC(display, gc);
+    if (window)
+        XDestroyWindow(display, window);
+    if (display)
+        XCloseDisplay(display);
+    display = NULL;
+    window = 0;
+    gc = 0;
+}
+#endif /* !_WIN32 */


### PR DESCRIPTION
## Summary
- add `platform.h` declaring basic window functions
- implement Win32 backend using DIB + StretchDIBits
- implement X11 backend using XImage + XPutImage
- hook platform library into CMake build

## Testing
- `cmake -S . -B build`
- ❌ `cmake --build build` *(fails: GLFW/glfw3.h: No such file or directory)*
- `cmake --build build --target test_obj_parser test_stl_parser test_step_parser test_mesh_builder test_constraints test_features test_kernel test_assembly`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68aba9733400832e869839c9fa7bab4d