### PR TITLE
Use platform API for framebuffer display

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ add_subdirectory(io)
 add_subdirectory(ui)
 add_subdirectory(platform)
 
-add_executable(three_d_app main.cpp)
+add_executable(three_d_app app/main.c)
 target_link_libraries(three_d_app
     kernel
     sketch

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -1,0 +1,35 @@
+#include "platform.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+#define WIDTH 640
+#define HEIGHT 480
+
+int main(void) {
+    if (platform_init("3D App", WIDTH, HEIGHT) != 0)
+        return 1;
+
+    uint32_t *fb = (uint32_t*)calloc(WIDTH * HEIGHT, sizeof(uint32_t));
+    if (!fb) {
+        platform_shutdown();
+        return 1;
+    }
+
+    for (int y = 0; y < HEIGHT; ++y) {
+        for (int x = 0; x < WIDTH; ++x) {
+            uint8_t r = (uint8_t)(255 * x / WIDTH);
+            uint8_t g = (uint8_t)(255 * y / HEIGHT);
+            fb[y * WIDTH + x] = 0xFF000000 | (r << 16) | (g << 8);
+        }
+    }
+
+    while (!platform_poll()) {
+        platform_present(fb);
+        platform_sleep(16);
+    }
+
+    free(fb);
+    platform_shutdown();
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- Replace SDL-based entry point with a simple platform_* based app that opens a window and presents a pixel buffer
- Update build system to compile the new C entry point

## Testing
- `cmake -S . -B build` *(pass)*
- `cmake --build build` *(fail: fatal error: GLFW/glfw3.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abad016c9c832eb6cfe9945c968940