### PR TITLE
Add triangle rasterizer with z-buffer

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(assembly)
 add_subdirectory(io)
 add_subdirectory(ui)
 add_subdirectory(platform)
+add_subdirectory(render)
 
 add_executable(three_d_app app/main.c)
 target_link_libraries(three_d_app
@@ -15,4 +16,5 @@ target_link_libraries(three_d_app
     io
     ui
     platform
+    render
 )

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -1,4 +1,7 @@
 #include "platform.h"
+#include "tri.h"
+#include "zbuf.h"
+#include <float.h>
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -10,24 +13,32 @@ int main(void) {
         return 1;
 
     uint32_t *fb = (uint32_t*)calloc(WIDTH * HEIGHT, sizeof(uint32_t));
-    if (!fb) {
+    float *zbuf = (float*)malloc(WIDTH * HEIGHT * sizeof(float));
+    if (!fb || !zbuf) {
+        free(fb);
+        free(zbuf);
         platform_shutdown();
         return 1;
     }
 
-    for (int y = 0; y < HEIGHT; ++y) {
-        for (int x = 0; x < WIDTH; ++x) {
-            uint8_t r = (uint8_t)(255 * x / WIDTH);
-            uint8_t g = (uint8_t)(255 * y / HEIGHT);
-            fb[y * WIDTH + x] = 0xFF000000 | (r << 16) | (g << 8);
-        }
-    }
+    zbuf_clear(zbuf, WIDTH, HEIGHT, FLT_MAX);
+
+    Vec3 a0 = {50.0f, 50.0f, 0.5f};
+    Vec3 b0 = {300.0f, 50.0f, 0.5f};
+    Vec3 c0 = {150.0f, 300.0f, 0.5f};
+    triangle_fill_halfspace(fb, zbuf, WIDTH, HEIGHT, a0, b0, c0, 0xFFFF0000);
+
+    Vec3 a1 = {100.0f, 100.0f, 0.3f};
+    Vec3 b1 = {350.0f, 100.0f, 0.3f};
+    Vec3 c1 = {200.0f, 350.0f, 0.3f};
+    triangle_fill_halfspace(fb, zbuf, WIDTH, HEIGHT, a1, b1, c1, 0xFF00FF00);
 
     while (!platform_poll()) {
         platform_present(fb);
         platform_sleep(16);
     }
 
+    free(zbuf);
     free(fb);
     platform_shutdown();
     return 0;

--- a/src/render/CMakeLists.txt
+++ b/src/render/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(render tri.c zbuf.c)
+target_include_directories(render PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/render/tri.c
+++ b/src/render/tri.c
@@ -1,0 +1,43 @@
+#include "tri.h"
+#include "zbuf.h"
+#include <math.h>
+
+static float edge_function(const Vec3 *a, const Vec3 *b, float x, float y) {
+    return (x - a->x) * (b->y - a->y) - (y - a->y) * (b->x - a->x);
+}
+
+void triangle_fill_halfspace(uint32_t *fb, float *zbuf, int width, int height,
+                             Vec3 v0, Vec3 v1, Vec3 v2, uint32_t color) {
+    float minx = floorf(fminf(fminf(v0.x, v1.x), v2.x));
+    float maxx = ceilf(fmaxf(fmaxf(v0.x, v1.x), v2.x));
+    float miny = floorf(fminf(fminf(v0.y, v1.y), v2.y));
+    float maxy = ceilf(fmaxf(fmaxf(v0.y, v1.y), v2.y));
+
+    if (minx < 0) minx = 0;
+    if (miny < 0) miny = 0;
+    if (maxx > width - 1) maxx = (float)(width - 1);
+    if (maxy > height - 1) maxy = (float)(height - 1);
+
+    float area = edge_function(&v0, &v1, v2.x, v2.y);
+    if (area == 0.0f)
+        return;
+
+    for (int y = (int)miny; y <= (int)maxy; ++y) {
+        for (int x = (int)minx; x <= (int)maxx; ++x) {
+            float px = x + 0.5f;
+            float py = y + 0.5f;
+            float w0 = edge_function(&v1, &v2, px, py);
+            float w1 = edge_function(&v2, &v0, px, py);
+            float w2 = edge_function(&v0, &v1, px, py);
+            if ((w0 >= 0 && w1 >= 0 && w2 >= 0) || (w0 <= 0 && w1 <= 0 && w2 <= 0)) {
+                w0 /= area;
+                w1 /= area;
+                w2 /= area;
+                float z = w0 * v0.z + w1 * v1.z + w2 * v2.z;
+                if (zbuf_test_and_write(zbuf, width, x, y, z)) {
+                    fb[y * width + x] = color;
+                }
+            }
+        }
+    }
+}

--- a/src/render/tri.h
+++ b/src/render/tri.h
@@ -1,0 +1,13 @@
+#ifndef TRI_H
+#define TRI_H
+
+#include <stdint.h>
+
+typedef struct {
+    float x, y, z;
+} Vec3;
+
+void triangle_fill_halfspace(uint32_t *fb, float *zbuf, int width, int height,
+                             Vec3 v0, Vec3 v1, Vec3 v2, uint32_t color);
+
+#endif /* TRI_H */

--- a/src/render/zbuf.c
+++ b/src/render/zbuf.c
@@ -1,0 +1,17 @@
+#include "zbuf.h"
+
+void zbuf_clear(float *zbuf, size_t width, size_t height, float value) {
+    size_t total = width * height;
+    for (size_t i = 0; i < total; ++i) {
+        zbuf[i] = value;
+    }
+}
+
+int zbuf_test_and_write(float *zbuf, size_t width, size_t x, size_t y, float z) {
+    size_t idx = y * width + x;
+    if (z < zbuf[idx]) {
+        zbuf[idx] = z;
+        return 1;
+    }
+    return 0;
+}

--- a/src/render/zbuf.h
+++ b/src/render/zbuf.h
@@ -1,0 +1,9 @@
+#ifndef ZBUF_H
+#define ZBUF_H
+
+#include <stddef.h>
+
+void zbuf_clear(float *zbuf, size_t width, size_t height, float value);
+int zbuf_test_and_write(float *zbuf, size_t width, size_t x, size_t y, float z);
+
+#endif /* ZBUF_H */


### PR DESCRIPTION
## Summary
- add simple z-buffer utilities
- implement half-space triangle rasterizer with depth test
- draw overlapping triangles using z-buffer in main app

## Testing
- `cmake --build build --target render`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68abae002f90832ebe5a8be2587c889a