### PR TITLE
Add orbit camera and matrix math to render rotating cube

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,13 @@ add_subdirectory(ui)
 add_subdirectory(platform)
 add_subdirectory(render)
 
-add_executable(three_d_app app/main.c)
+add_executable(three_d_app
+    app/main.c
+    app/camera.c
+    math/mat4.c)
+
+target_include_directories(three_d_app PRIVATE app math)
+
 target_link_libraries(three_d_app
     kernel
     sketch

--- a/src/app/camera.c
+++ b/src/app/camera.c
@@ -1,0 +1,23 @@
+#include "camera.h"
+#include <math.h>
+
+void camera_init(Camera *cam, float yaw, float pitch, float dist, Vec3 target) {
+    cam->yaw = yaw;
+    cam->pitch = pitch;
+    cam->dist = dist;
+    cam->target = target;
+}
+
+Mat4 camera_view_matrix(const Camera *cam) {
+    float cy = cosf(cam->yaw);
+    float sy = sinf(cam->yaw);
+    float cp = cosf(cam->pitch);
+    float sp = sinf(cam->pitch);
+    Vec3 eye = {
+        cam->target.x + cam->dist * cp * sy,
+        cam->target.y + cam->dist * sp,
+        cam->target.z + cam->dist * cp * cy
+    };
+    Vec3 up = {0.0f, 1.0f, 0.0f};
+    return mat4_look_at(eye, cam->target, up);
+}

--- a/src/app/camera.h
+++ b/src/app/camera.h
@@ -1,0 +1,17 @@
+#ifndef CAMERA_H
+#define CAMERA_H
+
+#include "tri.h"
+#include "mat4.h"
+
+typedef struct {
+    float yaw;
+    float pitch;
+    float dist;
+    Vec3 target;
+} Camera;
+
+void camera_init(Camera *cam, float yaw, float pitch, float dist, Vec3 target);
+Mat4 camera_view_matrix(const Camera *cam);
+
+#endif /* CAMERA_H */

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -1,12 +1,35 @@
 #include "platform.h"
 #include "tri.h"
 #include "zbuf.h"
+#include "camera.h"
 #include <float.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
+#include <math.h>
 
 #define WIDTH 640
 #define HEIGHT 480
+
+static void draw_line(uint32_t *fb, int width, int height, Vec3 a, Vec3 b, uint32_t color) {
+    int x0 = (int)a.x;
+    int y0 = (int)a.y;
+    int x1 = (int)b.x;
+    int y1 = (int)b.y;
+    int dx = abs(x1 - x0);
+    int dy = abs(y1 - y0);
+    int sx = x0 < x1 ? 1 : -1;
+    int sy = y0 < y1 ? 1 : -1;
+    int err = dx - dy;
+    while (1) {
+        if (x0 >= 0 && x0 < width && y0 >= 0 && y0 < height)
+            fb[y0 * width + x0] = color;
+        if (x0 == x1 && y0 == y1) break;
+        int e2 = 2 * err;
+        if (e2 > -dy) { err -= dy; x0 += sx; }
+        if (e2 < dx) { err += dx; y0 += sy; }
+    }
+}
 
 int main(void) {
     if (platform_init("3D App", WIDTH, HEIGHT) != 0)
@@ -21,21 +44,75 @@ int main(void) {
         return 1;
     }
 
-    zbuf_clear(zbuf, WIDTH, HEIGHT, FLT_MAX);
+    Camera cam;
+    camera_init(&cam, 0.7f, 0.5f, 5.0f, (Vec3){0.0f, 0.0f, 0.0f});
+    Mat4 proj = mat4_perspective(60.0f * (float)M_PI / 180.0f,
+                                 (float)WIDTH / (float)HEIGHT,
+                                 0.1f, 100.0f);
 
-    Vec3 a0 = {50.0f, 50.0f, 0.5f};
-    Vec3 b0 = {300.0f, 50.0f, 0.5f};
-    Vec3 c0 = {150.0f, 300.0f, 0.5f};
-    triangle_fill_halfspace(fb, zbuf, WIDTH, HEIGHT, a0, b0, c0, 0xFFFF0000);
+    Vec3 cube[8] = {
+        {-1, -1, -1}, { 1, -1, -1},
+        { 1,  1, -1}, {-1,  1, -1},
+        {-1, -1,  1}, { 1, -1,  1},
+        { 1,  1,  1}, {-1,  1,  1}
+    };
 
-    Vec3 a1 = {100.0f, 100.0f, 0.3f};
-    Vec3 b1 = {350.0f, 100.0f, 0.3f};
-    Vec3 c1 = {200.0f, 350.0f, 0.3f};
-    triangle_fill_halfspace(fb, zbuf, WIDTH, HEIGHT, a1, b1, c1, 0xFF00FF00);
+    uint32_t tris[12][3] = {
+        {0,1,2},{0,2,3},
+        {4,5,6},{4,6,7},
+        {0,4,5},{0,5,1},
+        {3,2,6},{3,6,7},
+        {1,5,6},{1,6,2},
+        {0,3,7},{0,7,4}
+    };
 
+    uint32_t edges[12][2] = {
+        {0,1},{1,2},{2,3},{3,0},
+        {4,5},{5,6},{6,7},{7,4},
+        {0,4},{1,5},{2,6},{3,7}
+    };
+
+    float angle = 0.0f;
     while (!platform_poll()) {
+        memset(fb, 0, WIDTH * HEIGHT * sizeof(uint32_t));
+        zbuf_clear(zbuf, WIDTH, HEIGHT, FLT_MAX);
+
+        Mat4 model = mat4_rotate_y(angle);
+        Mat4 view = camera_view_matrix(&cam);
+        Mat4 vp = mat4_mul(proj, view);
+        Mat4 mvp = mat4_mul(vp, model);
+
+        Vec3 projected[8];
+        for (int i = 0; i < 8; ++i) {
+            Vec4 v = {cube[i].x, cube[i].y, cube[i].z, 1.0f};
+            Vec4 p = mat4_mul_vec4(mvp, v);
+            float inv_w = 1.0f / p.w;
+            float x = p.x * inv_w;
+            float y = p.y * inv_w;
+            float z = p.z * inv_w;
+            projected[i].x = (x * 0.5f + 0.5f) * WIDTH;
+            projected[i].y = (1.0f - (y * 0.5f + 0.5f)) * HEIGHT;
+            projected[i].z = z * 0.5f + 0.5f;
+        }
+
+        for (int i = 0; i < 12; ++i) {
+            uint32_t i0 = tris[i][0];
+            uint32_t i1 = tris[i][1];
+            uint32_t i2 = tris[i][2];
+            triangle_fill_halfspace(fb, zbuf, WIDTH, HEIGHT,
+                                    projected[i0], projected[i1], projected[i2],
+                                    0xFF0080FF);
+        }
+
+        for (int i = 0; i < 12; ++i) {
+            uint32_t i0 = edges[i][0];
+            uint32_t i1 = edges[i][1];
+            draw_line(fb, WIDTH, HEIGHT, projected[i0], projected[i1], 0xFFFFFFFF);
+        }
+
         platform_present(fb);
         platform_sleep(16);
+        angle += 0.01f;
     }
 
     free(zbuf);
@@ -43,4 +120,3 @@ int main(void) {
     platform_shutdown();
     return 0;
 }
-

--- a/src/math/mat4.c
+++ b/src/math/mat4.c
@@ -1,0 +1,127 @@
+#include "mat4.h"
+#include <math.h>
+
+Mat4 mat4_identity(void) {
+    Mat4 m = { .m = {
+        1.0f, 0.0f, 0.0f, 0.0f,
+        0.0f, 1.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 1.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 1.0f
+    }};
+    return m;
+}
+
+Mat4 mat4_mul(Mat4 a, Mat4 b) {
+    Mat4 r;
+    for (int c = 0; c < 4; ++c) {
+        for (int r0 = 0; r0 < 4; ++r0) {
+            r.m[c*4 + r0] =
+                a.m[0*4 + r0] * b.m[c*4 + 0] +
+                a.m[1*4 + r0] * b.m[c*4 + 1] +
+                a.m[2*4 + r0] * b.m[c*4 + 2] +
+                a.m[3*4 + r0] * b.m[c*4 + 3];
+        }
+    }
+    return r;
+}
+
+Vec4 mat4_mul_vec4(Mat4 m, Vec4 v) {
+    Vec4 r;
+    r.x = m.m[0]*v.x + m.m[4]*v.y + m.m[8]*v.z + m.m[12]*v.w;
+    r.y = m.m[1]*v.x + m.m[5]*v.y + m.m[9]*v.z + m.m[13]*v.w;
+    r.z = m.m[2]*v.x + m.m[6]*v.y + m.m[10]*v.z + m.m[14]*v.w;
+    r.w = m.m[3]*v.x + m.m[7]*v.y + m.m[11]*v.z + m.m[15]*v.w;
+    return r;
+}
+
+Mat4 mat4_translate(float x, float y, float z) {
+    Mat4 m = mat4_identity();
+    m.m[12] = x;
+    m.m[13] = y;
+    m.m[14] = z;
+    return m;
+}
+
+Mat4 mat4_scale(float x, float y, float z) {
+    Mat4 m = { .m = {
+        x,    0.0f, 0.0f, 0.0f,
+        0.0f, y,    0.0f, 0.0f,
+        0.0f, 0.0f, z,    0.0f,
+        0.0f, 0.0f, 0.0f, 1.0f
+    }};
+    return m;
+}
+
+Mat4 mat4_rotate_x(float angle) {
+    float c = cosf(angle);
+    float s = sinf(angle);
+    Mat4 m = mat4_identity();
+    m.m[5] = c;  m.m[9] = -s;
+    m.m[6] = s;  m.m[10] = c;
+    return m;
+}
+
+Mat4 mat4_rotate_y(float angle) {
+    float c = cosf(angle);
+    float s = sinf(angle);
+    Mat4 m = mat4_identity();
+    m.m[0] = c;  m.m[8] = s;
+    m.m[2] = -s; m.m[10] = c;
+    return m;
+}
+
+Mat4 mat4_rotate_z(float angle) {
+    float c = cosf(angle);
+    float s = sinf(angle);
+    Mat4 m = mat4_identity();
+    m.m[0] = c;  m.m[4] = -s;
+    m.m[1] = s;  m.m[5] = c;
+    return m;
+}
+
+Mat4 mat4_perspective(float fovy, float aspect, float near_z, float far_z) {
+    float f = 1.0f / tanf(fovy * 0.5f);
+    Mat4 m = {0};
+    m.m[0] = f / aspect;
+    m.m[5] = f;
+    m.m[10] = (far_z + near_z) / (near_z - far_z);
+    m.m[14] = (2.0f * far_z * near_z) / (near_z - far_z);
+    m.m[11] = -1.0f;
+    return m;
+}
+
+static Vec3 vec3_sub(Vec3 a, Vec3 b) {
+    return (Vec3){a.x - b.x, a.y - b.y, a.z - b.z};
+}
+
+static Vec3 vec3_cross(Vec3 a, Vec3 b) {
+    return (Vec3){
+        a.y * b.z - a.z * b.y,
+        a.z * b.x - a.x * b.z,
+        a.x * b.y - a.y * b.x
+    };
+}
+
+static float vec3_dot(Vec3 a, Vec3 b) {
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+static Vec3 vec3_normalize(Vec3 v) {
+    float len = sqrtf(vec3_dot(v, v));
+    return (Vec3){v.x / len, v.y / len, v.z / len};
+}
+
+Mat4 mat4_look_at(Vec3 eye, Vec3 center, Vec3 up) {
+    Vec3 f = vec3_normalize(vec3_sub(center, eye));
+    Vec3 s = vec3_normalize(vec3_cross(f, up));
+    Vec3 u = vec3_cross(s, f);
+
+    Mat4 m = mat4_identity();
+    m.m[0] = s.x; m.m[4] = s.y; m.m[8]  = s.z;
+    m.m[1] = u.x; m.m[5] = u.y; m.m[9]  = u.z;
+    m.m[2] = -f.x; m.m[6] = -f.y; m.m[10] = -f.z;
+    m.m[12] = -vec3_dot(s, eye);
+    m.m[13] = -vec3_dot(u, eye);
+    m.m[14] = vec3_dot(f, eye);
+    return m;
+}

--- a/src/math/mat4.h
+++ b/src/math/mat4.h
@@ -1,0 +1,25 @@
+#ifndef MAT4_H
+#define MAT4_H
+
+#include "tri.h"
+
+typedef struct {
+    float m[16];
+} Mat4;
+
+typedef struct {
+    float x, y, z, w;
+} Vec4;
+
+Mat4 mat4_identity(void);
+Mat4 mat4_mul(Mat4 a, Mat4 b);
+Vec4 mat4_mul_vec4(Mat4 m, Vec4 v);
+Mat4 mat4_translate(float x, float y, float z);
+Mat4 mat4_scale(float x, float y, float z);
+Mat4 mat4_rotate_x(float angle);
+Mat4 mat4_rotate_y(float angle);
+Mat4 mat4_rotate_z(float angle);
+Mat4 mat4_perspective(float fovy, float aspect, float near_z, float far_z);
+Mat4 mat4_look_at(Vec3 eye, Vec3 center, Vec3 up);
+
+#endif /* MAT4_H */


### PR DESCRIPTION
## Summary
- Add simple orbit camera supporting yaw, pitch and distance
- Implement 4x4 matrix math helpers for transforms and projections
- Render a rotating cube in main using model-view-projection and wireframe overlay

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: GLFW/glfw3.h: No such file or directory)*
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68abb2264cc8832ea11bb54dd47e968a