### PR TITLE
Add basic 2D solver and constraint UI panel

### DIFF
--- a/src/sketch/CMakeLists.txt
+++ b/src/sketch/CMakeLists.txt
@@ -3,4 +3,6 @@ add_library(sketch
     constraint_manager.cpp
     entity_circle.cpp
     entity_line.cpp
+    entity2d.c
+    solver.c
 )

--- a/src/sketch/entity2d.c
+++ b/src/sketch/entity2d.c
@@ -1,0 +1,16 @@
+#include "entity2d.h"
+
+Point2D point2d(double x, double y) {
+    Point2D p = {x, y};
+    return p;
+}
+
+Line2D line2d(Point2D p1, Point2D p2) {
+    Line2D l = {p1, p2};
+    return l;
+}
+
+Circle2D circle2d(Point2D c, double r) {
+    Circle2D circ = {c, r};
+    return circ;
+}

--- a/src/sketch/entity2d.h
+++ b/src/sketch/entity2d.h
@@ -1,0 +1,27 @@
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    double x;
+    double y;
+} Point2D;
+
+typedef struct {
+    Point2D p1;
+    Point2D p2;
+} Line2D;
+
+typedef struct {
+    Point2D center;
+    double radius;
+} Circle2D;
+
+Point2D point2d(double x, double y);
+Line2D line2d(Point2D p1, Point2D p2);
+Circle2D circle2d(Point2D c, double r);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/sketch/solver.c
+++ b/src/sketch/solver.c
@@ -1,0 +1,93 @@
+#include "solver.h"
+#include <math.h>
+
+void solver_init(Solver *s) {
+    s->point_count = 0;
+    s->line_count = 0;
+    s->circle_count = 0;
+    s->constraint_count = 0;
+}
+
+Point2D *solver_add_point(Solver *s, double x, double y) {
+    Point2D p = {x, y};
+    s->points[s->point_count] = p;
+    return &s->points[s->point_count++];
+}
+
+Line2D *solver_add_line(Solver *s, Point2D p1, Point2D p2) {
+    Line2D l = {p1, p2};
+    s->lines[s->line_count] = l;
+    return &s->lines[s->line_count++];
+}
+
+Circle2D *solver_add_circle(Solver *s, Point2D c, double r) {
+    Circle2D circ = {c, r};
+    s->circles[s->circle_count] = circ;
+    return &s->circles[s->circle_count++];
+}
+
+void solver_add_constraint(Solver *s, ConstraintType type, void *a, void *b, double value) {
+    Constraint c = {type, a, b, value};
+    s->constraints[s->constraint_count++] = c;
+}
+
+static void apply_constraint(Constraint *c) {
+    switch (c->type) {
+    case CONSTRAINT_HORIZONTAL: {
+        Line2D *l = (Line2D *)c->a;
+        double avg = (l->p1.y + l->p2.y) / 2.0;
+        l->p1.y = l->p2.y = avg;
+        break;
+    }
+    case CONSTRAINT_VERTICAL: {
+        Line2D *l = (Line2D *)c->a;
+        double avg = (l->p1.x + l->p2.x) / 2.0;
+        l->p1.x = l->p2.x = avg;
+        break;
+    }
+    case CONSTRAINT_PARALLEL: {
+        Line2D *l1 = (Line2D *)c->a;
+        Line2D *l2 = (Line2D *)c->b;
+        double dx = l1->p2.x - l1->p1.x;
+        double dy = l1->p2.y - l1->p1.y;
+        l2->p2.x = l2->p1.x + dx;
+        l2->p2.y = l2->p1.y + dy;
+        break;
+    }
+    case CONSTRAINT_PERPENDICULAR: {
+        Line2D *l1 = (Line2D *)c->a;
+        Line2D *l2 = (Line2D *)c->b;
+        double dx = l1->p2.x - l1->p1.x;
+        double dy = l1->p2.y - l1->p1.y;
+        l2->p2.x = l2->p1.x - dy;
+        l2->p2.y = l2->p1.y + dx;
+        break;
+    }
+    case CONSTRAINT_COINCIDENT: {
+        Point2D *p1 = (Point2D *)c->a;
+        Point2D *p2 = (Point2D *)c->b;
+        p2->x = p1->x;
+        p2->y = p1->y;
+        break;
+    }
+    case CONSTRAINT_DISTANCE: {
+        Point2D *p1 = (Point2D *)c->a;
+        Point2D *p2 = (Point2D *)c->b;
+        double dx = p2->x - p1->x;
+        double dy = p2->y - p1->y;
+        double len = sqrt(dx * dx + dy * dy);
+        if (len != 0.0) {
+            double scale = c->value / len;
+            p2->x = p1->x + dx * scale;
+            p2->y = p1->y + dy * scale;
+        }
+        break;
+    }
+    }
+}
+
+void solver_solve(Solver *s) {
+    for (int i = 0; i < s->constraint_count; ++i) {
+        apply_constraint(&s->constraints[i]);
+    }
+}

--- a/src/sketch/solver.h
+++ b/src/sketch/solver.h
@@ -1,0 +1,47 @@
+#pragma once
+#include "entity2d.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SOLVER_MAX_ENTITIES 64
+#define SOLVER_MAX_CONSTRAINTS 64
+
+typedef enum {
+    CONSTRAINT_HORIZONTAL,
+    CONSTRAINT_VERTICAL,
+    CONSTRAINT_PARALLEL,
+    CONSTRAINT_PERPENDICULAR,
+    CONSTRAINT_COINCIDENT,
+    CONSTRAINT_DISTANCE
+} ConstraintType;
+
+typedef struct {
+    ConstraintType type;
+    void *a;
+    void *b;
+    double value;
+} Constraint;
+
+typedef struct {
+    Point2D points[SOLVER_MAX_ENTITIES];
+    int point_count;
+    Line2D lines[SOLVER_MAX_ENTITIES];
+    int line_count;
+    Circle2D circles[SOLVER_MAX_ENTITIES];
+    int circle_count;
+    Constraint constraints[SOLVER_MAX_CONSTRAINTS];
+    int constraint_count;
+} Solver;
+
+void solver_init(Solver *s);
+Point2D *solver_add_point(Solver *s, double x, double y);
+Line2D *solver_add_line(Solver *s, Point2D p1, Point2D p2);
+Circle2D *solver_add_circle(Solver *s, Point2D c, double r);
+void solver_add_constraint(Solver *s, ConstraintType type, void *a, void *b, double value);
+void solver_solve(Solver *s);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ui
     ui.cpp
     imgui_layer.cpp
     property_panel.cpp
+    constraint_panel.cpp
     sketch_view.cpp
     viewport.cpp
 )

--- a/src/ui/constraint_panel.cpp
+++ b/src/ui/constraint_panel.cpp
@@ -1,0 +1,15 @@
+#include "constraint_panel.h"
+#include <imgui.h>
+
+namespace ui {
+
+void constraint_panel(Solver *solver) {
+    if (ImGui::Begin("Constraints")) {
+        if (ImGui::Button("Solve")) {
+            solver_solve(solver);
+        }
+        ImGui::End();
+    }
+}
+
+} // namespace ui

--- a/src/ui/constraint_panel.h
+++ b/src/ui/constraint_panel.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "../sketch/solver.h"
+
+namespace ui {
+void constraint_panel(Solver *solver);
+}


### PR DESCRIPTION
## Summary
- Introduce simple 2D entities (point, line, circle) and a lightweight constraint solver supporting horizontal, vertical, parallel, perpendicular, coincident, and distance relations.
- Provide a small ImGui constraint panel with a solve button for basic constraint management.
- Wire new sources into sketch and ui CMake targets.

## Testing
- `cmake --build build --target test_constraints`
- `cmake --build build --target test_model_io test_obj_parser test_stl_parser test_step_parser test_mesh_builder test_features test_kernel test_assembly`
- `ctest --test-dir build`
- `cmake --build build` *(fails: fatal error: GLFW/glfw3.h: No such file or directory)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68abb372a690832eafc8cb722d5cee10